### PR TITLE
Contact.html moved to remove from robot indexing, quotations

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,0 +1,34 @@
+<div class="" id="contact">
+  <h2>Contact</h2>
+  <div class="underline_divider"></div>
+  <div class="row">
+    <div class="contact-form col-md-6 col-md-offset-2 col-sm-6 col-sm-offset-2">
+      <h3 id="touch">Get in touch</h3>
+      <form role="form" method="POST" action="//formspree.io/contact@pennlabs.org">
+        <div class="form-group">
+          <input type="text" name="name" class="form-control" placeholder="Name">
+        </div>
+        <div class="form-group">
+          <input type="email" name="email" class="form-control" placeholder="Email">
+        </div>
+        <div class="form-group">
+          <input type="text" name="subject" class="form-control" placeholder="Subject">
+        </div>
+        <div class="form-group">
+          <textarea name="message" class="form-control" rows="3" placeholder="Message"></textarea>
+        </div>
+        <input type="text" name="_gotcha" style="display:none" />
+        <input type="submit" class="btn btn-default" value="Submit">
+      </form>
+    </div>
+
+    <div class="help-form col-md-4 col-sm-4">
+      <h3 id="help">Need help?</h3>
+      <ul id="help_list">
+        <li><span class="glyphicon glyphicon-comment"></span> <a target="_blank" href="https://goo.gl/forms/6gdCr3NIaH6o1dSL2">Drop us a bug report.</a></li>
+        <li><span class="glyphicon glyphicon-bullhorn"></span> <a target="_blank" href="https://goo.gl/forms/6gdCr3NIaH6o1dSL2">Give us some ideas.</a></li>
+        <li><span class="glyphicon glyphicon-list-alt"></span> <a href="/docs/index.html" target="_blank">Read the docs.</a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href='http://fonts.googleapis.com/css?family=Lato:300,300italic,400,700,900' rel='stylesheet' type='text/css'>
+    <link href="http://fonts.googleapis.com/css?family=Lato:300,300italic,400,700,900" rel="stylesheet" type="text/css">
     <meta name="description" content="Penn Labs is a non-profit, student-run organization that creates, maintains, and improves student-run technology at the University of Pennsylvania.">
     <meta name="author" content="Penn Labs">
     <title>Penn Labs</title>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ layout: default
   <div class="underline_divider"></div>
 
   {% for member in site.data.bios %}
-    {% capture linkedName %}<a href='{{ member.website }}' target='_blank'>{{ member.firstname }}</a>{% endcapture %}
+    {% capture linkedName %}<a href="{{ member.website }}" target="_blank">{{ member.firstname }}</a>{% endcapture %}
     <div class="item">
       <div class="image img-responsive">
         <img src="{{ member.image }}">
@@ -112,38 +112,5 @@ layout: default
   <p>Made@Penn is a Labs project to showcase the work of student developers. Our goal is to strengthen the community of builders at Penn. If you'd like to demo your work, submit <a class="text_link" href="http://madeatpenn.pennlabs.org">here</a>.</p>
 </div>
 
-<div class="" id="contact">
-  <h2>Contact</h2>
-  <div class="underline_divider"></div>
-  <div class="row">
-    <div class="contact-form col-md-6 col-md-offset-2 col-sm-6 col-sm-offset-2">
-      <h3 id="touch">Get in touch</h3>
-      <form role="form" method="POST" action="//formspree.io/contact@pennlabs.org">
-        <div class="form-group">
-          <input type="text" name="name" class="form-control" placeholder="Name">
-        </div>
-        <div class="form-group">
-          <input type="email" name="email" class="form-control" placeholder="Email">
-        </div>
-        <div class="form-group">
-          <input type="text" name="subject" class="form-control" placeholder="Subject">
-        </div>
-        <div class="form-group">
-          <textarea name="message" class="form-control" rows="3" placeholder="Message"></textarea>
-        </div>
-        <input type="text" name="_gotcha" style="display:none" />
-        <input type="submit" class="btn btn-default" value="Submit">
-      </form>
-    </div>
-
-    <div class="help-form col-md-4 col-sm-4">
-      <h3 id="help">Need help?</h3>
-      <ul id="help_list">
-        <li><span class="glyphicon glyphicon-comment"></span> <a target="_blank" href="https://goo.gl/forms/6gdCr3NIaH6o1dSL2">Drop us a bug report.</a></li>
-        <li><span class="glyphicon glyphicon-bullhorn"></span> <a target="_blank" href="https://goo.gl/forms/6gdCr3NIaH6o1dSL2">Give us some ideas.</a></li>
-        <li><span class="glyphicon glyphicon-list-alt"></span> <a href="/docs/index.html" target="_blank">Read the docs.</a></li>
-      </ul>
-    </div>
-  </div>
-</div>
+{% include contact.html %}
 </div>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /_includes/contact.html


### PR DESCRIPTION
- Changed single quotes to double quotes as specified by my HTML linter (apparently they're better for <a> tags???)
- Moved contact section over to contact.html to disallow bots from crawling form (in an effort to avoid bots filling out the form; unsure whether this will be effective.)