### PR TITLE
Add redirects for mobile feedback

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
   plugins: [
     `gatsby-plugin-react-helmet`,
     `gatsby-transformer-sharp`,
+    `gatsby-plugin-meta-redirect`,
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -100,7 +100,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 }
 
 exports.createPages = async ({ graphql, actions, reporter }) => {
-  const { createPage } = actions
+  const { createPage, createRedirect } = actions
 
   /**
    * Create pages for members
@@ -235,5 +235,21 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
         return `/blog/page`
       }
     },
+  })
+
+  // Create redirect for mobile feedback
+  
+  // HACK: This is hardcoded for now, in the future we probably want a more
+  // scalable way to handle link shortening
+  const feedbackForms = [
+    { slug: 'android', url: 'https://airtable.com/appFRa4NQvNMEbWsA/shrn4VbSQa8QDj8OG' },
+    { slug: 'ios', url: 'https://airtable.com/appFRa4NQvNMEbWsA/shrVrNXT4PpI7nqvD' },
+  ]
+
+  feedbackForms.forEach(({ slug, url }) => {
+    createRedirect({
+      fromPath: `/feedback/${slug}`,
+      toPath: url,
+    })
   })
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gatsby-plugin-feed": "^2.13.0",
     "gatsby-plugin-google-analytics": "^2.11.0",
     "gatsby-plugin-manifest": "^2.12.0",
+    "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-offline": "^3.10.0",
     "gatsby-plugin-react-helmet": "^3.10.0",
     "gatsby-plugin-remote-images": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,6 +6031,15 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -6247,6 +6256,13 @@ gatsby-plugin-manifest@^2.12.0:
     gatsby-plugin-utils "^0.9.0"
     semver "^7.3.2"
     sharp "^0.27.0"
+
+gatsby-plugin-meta-redirect@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-meta-redirect/-/gatsby-plugin-meta-redirect-1.1.1.tgz#058e8e53edff38dc44d3bb6153109d01c910f863"
+  integrity sha512-Oc4qgU3SlDUM9qoxIMKO+re2bdMs3/a2KXrfL65gb8XMLsHylBbveWtXZRhgjd2QDL/49RX4S9SEykuadRju2w==
+  dependencies:
+    fs-extra "^7.0.0"
 
 gatsby-plugin-offline@^3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This PR adds `/feedback/android` and `/feedback/ios` routes that redirect to their respective feedback forms. We're implementing these as redirects since changing the links would otherwise require us to re-deploy new versions of the app, which involves a lot of overhead (particularly due to app review processes.) Hopefully this change wil be the last time we have to do such a thing.

Currently the links are hardcoded, but over the next semester I'll work on a more scalable way of setting up arbitrary redirects for things like this.
