### PR TITLE
Finegrained roles on team-by-team basis

### DIFF
--- a/src/components/Team/TeamMemberPreview.tsx
+++ b/src/components/Team/TeamMemberPreview.tsx
@@ -42,14 +42,8 @@ const Image = styled(BackgroundImage)`
   border-radius: ${BORDER_RADIUS};
 `
 
-export const TeamMemberPreview = ({
-  name,
-  roles,
-  pennkey,
-  localImage,
-  semester_joined: semesterJoined,
-  alumnus,
-}: IMember) => (
+export const TeamMemberPreview = ({ name, roles, pennkey, localImage, semesterJoined}: IMember): React.ReactElement => {
+  return (
   <Col margin={M2} sm={12} md={6} lg={3} key={pennkey}>
     <StyledLink to={TEAM_MEMBER_ROUTE(pennkey)}>
       {
@@ -68,4 +62,5 @@ export const TeamMemberPreview = ({
       )}
     </StyledLink>
   </Col>
-)
+  )
+}

--- a/src/components/Team/Teams.tsx
+++ b/src/components/Team/Teams.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ITeam, IMember } from '../../types'
+import { ITeam, IMember, ITeamMember } from '../../types'
 import { Fade, Section, H2, Row, Col, P } from '../../shared'
 import { M2 } from '../../constants/measurements'
 import { TeamMemberPreview } from './TeamMemberPreview'
@@ -10,7 +10,7 @@ interface ITeams {
 
 const TEAM_LEAD = 'Team Lead'
 
-const leadsFirst = (members: IMember[]): IMember[] => {
+const leadsFirst = (members: ITeamMember[]): ITeamMember[] => {
   if (!members) return []
 
   return members.sort((m1, m2): number => {
@@ -39,7 +39,7 @@ export const Teams = ({ teams }: ITeams) => (
           </Row>
 
           <Row margin={M2}>
-            {leadsFirst(members).map((props: IMember) => (
+            {leadsFirst(members).map((props: ITeamMember) => (
               <TeamMemberPreview key={props.pennkey} {...props} />
             ))}
           </Row>

--- a/src/json/alumni/aanten.json
+++ b/src/json/alumni/aanten.json
@@ -5,9 +5,11 @@
   "school": "College of Arts & Sciences",
   "bio": "Hi! I'm a sophomore studying math & CS in the college and an avid proponent of Buffalo Wild Wings.",
   "hometown": "Long Island, NY",
-  "team": "Penn Mobile",
-  "roles": [
-    "iOS Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/i271XGY.jpg",
   "linkedin": "https://www.linkedin.com/in/andrew-antenberg/",

--- a/src/json/alumni/anagwekar.json
+++ b/src/json/alumni/anagwekar.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hey! My name is Ansh Nagwekar, and I am a freshman studying NETS at Penn. Outside the lab, you can probably find me hiking up a mountain, playing spikeball, eating Airheads, or overanalyzing song lyrics!",
   "hometown": "San Jose, California",
-  "team": "Penn Courses",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/LITbDoC.jpg?1",
   "linkedin": "https://www.linkedin.com/in/ansh-nagwekar/",
   "website": "",
@@ -16,4 +20,3 @@
   "graduation_year": 2025,
   "job": null
 }
-  

--- a/src/json/alumni/annajg.json
+++ b/src/json/alumni/annajg.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "My holy trinity consists of painting, pasta, and Percy Jackson. Also a VSCO HB2 enthusiast :)",
   "hometown": "Edison, NJ",
-  "team": "Penn Mobile",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/acetToI.jpg",
   "linkedin": "https://www.linkedin.com/in/annasjiang/",

--- a/src/json/alumni/annawang.json
+++ b/src/json/alumni/annawang.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "former wii fit user",
   "hometown": "Saratoga, CA",
-  "team": "Penn Mobile",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/QAXyuBW.jpg",
   "linkedin": "https://www.linkedin.com/in/annalinwang/",

--- a/src/json/alumni/annipan.json
+++ b/src/json/alumni/annipan.json
@@ -1,19 +1,21 @@
 {
-  "name": "Anni Pan",
-  "pennkey": "annipan",
-  "major": "Computer Science + Mathematics",
+  "name": "Anna Wang",
+  "pennkey": "annawang",
+  "major": "Digital Media Design",
   "school": "Engineering",
-  "bio": "Hi there! I'm a sophomore at Penn studying CIS + MATH. In my free time I can be found playing with my cat, practicing guitar, reading or sleeping ;)",
-  "hometown": "Nanjing, China",
-  "team": "Penn Mobile",
-  "roles": [
-    "Backend Engineer"
+  "bio": "former wii fit user",
+  "hometown": "Saratoga, CA",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
   ],
-  "photo": "https://i.imgur.com/S1kfAT4.jpg",
-  "linkedin": "https://www.linkedin.com/in/anni-pan-17b95b179/",
-  "website": "https://annypan.github.io/personal_website/",
-  "github": "https://github.com/annypan",
-  "semester_joined": "2021A",
+  "photo": "https://i.imgur.com/QAXyuBW.jpg",
+  "linkedin": "https://www.linkedin.com/in/annalinwang/",
+  "website": "http://annalinwang.com/",
+  "github": "https://github.com/annalinwang",
+  "semester_joined": "2019C",
   "alumnus": true,
   "graduation_year": 2023,
   "job": null

--- a/src/json/alumni/annipan.json
+++ b/src/json/alumni/annipan.json
@@ -1,21 +1,21 @@
 {
-  "name": "Anna Wang",
-  "pennkey": "annawang",
-  "major": "Digital Media Design",
+  "name": "Anni Pan",
+  "pennkey": "annipan",
+  "major": "Computer Science + Mathematics",
   "school": "Engineering",
-  "bio": "former wii fit user",
-  "hometown": "Saratoga, CA",
+  "bio": "Hi there! I'm a sophomore at Penn studying CIS + MATH. In my free time I can be found playing with my cat, practicing guitar, reading or sleeping ;)",
+  "hometown": "Nanjing, China",
   "teamRoles": [
     {
       "team": "Penn Mobile",
-      "roles": ["Designer"]
+      "roles": ["Backend Engineer"]
     }
   ],
-  "photo": "https://i.imgur.com/QAXyuBW.jpg",
-  "linkedin": "https://www.linkedin.com/in/annalinwang/",
-  "website": "http://annalinwang.com/",
-  "github": "https://github.com/annalinwang",
-  "semester_joined": "2019C",
+  "photo": "https://i.imgur.com/S1kfAT4.jpg",
+  "linkedin": "https://www.linkedin.com/in/anni-pan-17b95b179/",
+  "website": "https://annypan.github.io/personal_website/",
+  "github": "https://github.com/annypan",
+  "semester_joined": "2021A",
   "alumnus": true,
   "graduation_year": 2023,
   "job": null

--- a/src/json/alumni/armaant.json
+++ b/src/json/alumni/armaant.json
@@ -5,8 +5,12 @@
   "pennkey": "armaant",
   "bio": "Hi, I'm Armaan! I'm studying computer science and finance and am the Team Lead for [Platform](https://platform.pennlabs.org/). I'm super interested in Sysadmin and DevOps. If you want to know more about me or any of my recent projects, check out [my website](https://armaan.tobaccowalla.com/)!",
   "hometown": "Upper Saddle River, NJ",
-  "team": "Platform",
-  "roles": ["Director Emeritus", "Team Lead", "Backend Engineer", "DevOps"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Director Emeritus", "Team Lead", "Backend Engineer", "DevOps"]
+    }
+  ],
   "photo": "https://i.imgur.com/wDkP3rs.jpg",
   "linkedin": "https://www.linkedin.com/in/tobaccowallaa/",
   "website": "https://armaan.tobaccowalla.com",

--- a/src/json/alumni/astrike.json
+++ b/src/json/alumni/astrike.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Backend Dev on Penn mobile, CIS Major 2023 :)",
   "hometown": "Johannesburg, South Africa",
-  "team": "Penn Mobile",
-  "roles": [
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/lXMeM7y.jpg",
   "linkedin": null,

--- a/src/json/alumni/avnia.json
+++ b/src/json/alumni/avnia.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "I'm a sophomore studying Comp + Cog Sci and hopefully minoring in Creative Writing. I love movies, food, and playing obscure board games with my siblings :)",
   "hometown": "New York City",
-  "team": "Penn Courses",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/V4RclNb.png",
   "linkedin": null,

--- a/src/json/alumni/bqle.json
+++ b/src/json/alumni/bqle.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi! I'm a freshman from Vietnam and I'm a backend engineer for OHQ. In my freetime, I like to watch movie summaries and take long walks",
   "hometown": "Ho Chi Minh City, Vietnam",
-  "team": "Office Hours Queue",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/RfPYyuL.jpg",
   "linkedin": "https://www.linkedin.com/in/bqle/",
   "website": "",
@@ -16,4 +20,3 @@
   "graduation_year": 2025,
   "job": null
 }
-  

--- a/src/json/alumni/brandw.json
+++ b/src/json/alumni/brandw.json
@@ -5,8 +5,12 @@
   "school": "Engineering & Wharton",
   "bio": "Hi y’all, I’m Brandon! I’m a freshman studying M&T, and I’m working on DevOps this year. I also love hiking, tennis, and playing Avalon and Catan with friends!",
   "hometown": "Plano, TX",
-  "team": "Platform",
-  "roles": ["DevOps"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
+  ],
   "photo": "https://i.imgur.com/x0Qowwv.jpg",
   "linkedin": "https://www.linkedin.com/in/brandonzwang/",
   "website": "https://www.brandonwang.com/",

--- a/src/json/alumni/cbaile.json
+++ b/src/json/alumni/cbaile.json
@@ -1,21 +1,22 @@
 {
-  "name": "Baile Chen",
-  "major": "Computer Science",
-  "school": "Engineering",
-  "pennkey": "cbaile",
-  "bio": "Hi,I am Peter studying Computer Science.",
-  "hometown": "Hong Kong",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Backend Engineer",
-    "Frontend Engineer"
+  "name": "Brandon Wang",
+  "pennkey": "brandw",
+  "major": "Computer Science + Finance",
+  "school": "Engineering & Wharton",
+  "bio": "Hi y’all, I’m Brandon! I’m a freshman studying M&T, and I’m working on DevOps this year. I also love hiking, tennis, and playing Avalon and Catan with friends!",
+  "hometown": "Plano, TX",
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
   ],
-  "photo": "https://i.imgur.com/LLPmYNK.jpg",
-  "linkedin": "https://www.linkedin.com/in/peter-chen-ba7847153/",
-  "website": null,
-  "github": "https://github.com/peterbaile",
-  "semester_joined": "2019A",
+  "photo": "https://i.imgur.com/x0Qowwv.jpg",
+  "linkedin": "https://www.linkedin.com/in/brandonzwang/",
+  "website": "https://www.brandonwang.com/",
+  "github": "https://github.com/brandonwang1/",
+  "semester_joined": "2020C",
   "alumnus": true,
-  "graduation_year": null,
+  "graduation_year": 2024,
   "job": null
 }

--- a/src/json/alumni/cbaile.json
+++ b/src/json/alumni/cbaile.json
@@ -1,22 +1,22 @@
 {
-  "name": "Brandon Wang",
-  "pennkey": "brandw",
-  "major": "Computer Science + Finance",
-  "school": "Engineering & Wharton",
-  "bio": "Hi y’all, I’m Brandon! I’m a freshman studying M&T, and I’m working on DevOps this year. I also love hiking, tennis, and playing Avalon and Catan with friends!",
-  "hometown": "Plano, TX",
+  "name": "Baile Chen",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "pennkey": "cbaile",
+  "bio": "Hi,I am Peter studying Computer Science.",
+  "hometown": "Hong Kong",
   "teamRoles": [
     {
-      "team": "Platform",
-      "roles": ["DevOps"]
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer", "Frontend Engineer"]
     }
   ],
-  "photo": "https://i.imgur.com/x0Qowwv.jpg",
-  "linkedin": "https://www.linkedin.com/in/brandonzwang/",
-  "website": "https://www.brandonwang.com/",
-  "github": "https://github.com/brandonwang1/",
-  "semester_joined": "2020C",
+  "photo": "https://i.imgur.com/LLPmYNK.jpg",
+  "linkedin": "https://www.linkedin.com/in/peter-chen-ba7847153/",
+  "website": null,
+  "github": "https://github.com/peterbaile",
+  "semester_joined": "2019A",
   "alumnus": true,
-  "graduation_year": 2024,
+  "graduation_year": null,
   "job": null
 }

--- a/src/json/alumni/ccabo.json
+++ b/src/json/alumni/ccabo.json
@@ -1,18 +1,22 @@
 {
-  "name": "Cameron Cabo",
-  "major": "Computer Science + Management",
-  "school": "Engineering & Wharton",
-  "pennkey": "ccabo",
-  "bio": "I'm a senior studying Computer Science and Management of Entrepreneurship and Innovation. I'm passionate for building products which people enjoy using and learn from. In my free time I like working out, learning new things, and exploring new places ?",
-  "hometown": "Wellesley, MA",
-  "team": "Penn Basics",
-  "roles": ["Team Lead", "Frontend Engineer", "Director Emeritus"],
-  "photo": "https://i.imgur.com/3yQizZb.jpg",
-  "linkedin": "https://www.linkedin.com/in/cameroncabo",
-  "website": "https://www.cameroncabo.com",
-  "github": "https://www.github.com/ccabo1",
-  "semester_joined": "2017C",
-  "alumnus": false,
+  "name": "Baile Chen",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "pennkey": "cbaile",
+  "bio": "Hi,I am Peter studying Computer Science.",
+  "hometown": "Hong Kong",
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer", "Frontend Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/LLPmYNK.jpg",
+  "linkedin": "https://www.linkedin.com/in/peter-chen-ba7847153/",
+  "website": null,
+  "github": "https://github.com/peterbaile",
+  "semester_joined": "2019A",
+  "alumnus": true,
   "graduation_year": null,
   "job": null
 }

--- a/src/json/alumni/ccabo.json
+++ b/src/json/alumni/ccabo.json
@@ -1,22 +1,22 @@
 {
-  "name": "Baile Chen",
-  "major": "Computer Science",
-  "school": "Engineering",
-  "pennkey": "cbaile",
-  "bio": "Hi,I am Peter studying Computer Science.",
-  "hometown": "Hong Kong",
+  "name": "Cameron Cabo",
+  "major": "Computer Science + Management",
+  "school": "Engineering & Wharton",
+  "pennkey": "ccabo",
+  "bio": "I'm a senior studying Computer Science and Management of Entrepreneurship and Innovation. I'm passionate for building products which people enjoy using and learn from. In my free time I like working out, learning new things, and exploring new places ?",
+  "hometown": "Wellesley, MA",
   "teamRoles": [
     {
-      "team": "Office Hours Queue",
-      "roles": ["Backend Engineer", "Frontend Engineer"]
+      "team": "Penn Basics",
+      "roles": ["Team Lead", "Frontend Engineer", "Director Emeritus"]
     }
   ],
-  "photo": "https://i.imgur.com/LLPmYNK.jpg",
-  "linkedin": "https://www.linkedin.com/in/peter-chen-ba7847153/",
-  "website": null,
-  "github": "https://github.com/peterbaile",
-  "semester_joined": "2019A",
-  "alumnus": true,
+  "photo": "https://i.imgur.com/3yQizZb.jpg",
+  "linkedin": "https://www.linkedin.com/in/cameroncabo",
+  "website": "https://www.cameroncabo.com",
+  "github": "https://www.github.com/ccabo1",
+  "semester_joined": "2017C",
+  "alumnus": false,
   "graduation_year": null,
   "job": null
 }

--- a/src/json/alumni/ccunning.json
+++ b/src/json/alumni/ccunning.json
@@ -5,8 +5,12 @@
   "pennkey": "ccunning",
   "bio": "I'm a back-end developer with Penn Courses, working mainly on the Penn Course Alert refresh and Penn Course Plan.  I'm studying Computer Science at SEAS and my other academic interests include mathematics, economics, game theory, physics, design thinking, and engineering.  In my free time I love biking, sailing, and KSP.",
   "hometown": "New York, NY",
-  "team": "Penn Courses",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/qf46nbE.jpg",
   "linkedin": "https://www.linkedin.com/in/charles-cunningham-049a81193/",
   "website": "https://www.charleycunningham.com",

--- a/src/json/alumni/cfair.json
+++ b/src/json/alumni/cfair.json
@@ -5,9 +5,11 @@
   "pennkey": "cfair",
   "bio": "Cole is an M&T student interested in how the worlds of business and engineering intersect in fields ranging from technology to fashion to food. He spends his free time exploring interests in film, cooking, basketball, and service in the local community.",
   "hometown": "Charlottesville, VA",
-  "team": "Penn Clubs",
-  "roles": [
-    "Business Developer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Business Developer"]
+    }
   ],
   "photo": "https://i.imgur.com/linhR2x.jpg",
   "linkedin": "https://www.linkedin.com/in/cole-fairchild-a78522174",

--- a/src/json/alumni/cindyhao.json
+++ b/src/json/alumni/cindyhao.json
@@ -5,9 +5,11 @@
   "pennkey": "cindyhao",
   "bio": "I applied to Penn as PPE but somehow ended up in CIS. Love podcasts and going to grocery stores",
   "hometown": "Plano, TX",
-  "team": "Penn Clubs",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/z0nLSnF.jpg",
   "linkedin": "https://www.linkedin.com/in/cindyhao/",

--- a/src/json/alumni/conswang.json
+++ b/src/json/alumni/conswang.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hello friends, I'm a sophomore who likes long walks in urban parks and fluffy things :)",
   "hometown": "Toronto, Canada",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/wXKaQ3H.jpg",
   "linkedin": "https://www.linkedin.com/in/conswang/",

--- a/src/json/alumni/cphalen.json
+++ b/src/json/alumni/cphalen.json
@@ -5,11 +5,11 @@
   "pennkey": "cphalen",
   "bio": "I'm a junior studying Networked Social Systems Engineering. When I'm not hiding from the Penn Labs front-end, I love watching old movies, studying mathematics, and playing lacrosse!",
   "hometown": "Chicago, IL",
-  "team": "Penn Clubs",
-  "roles": [
-    "Director Emeritus",
-    "Team Lead",
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Director Emeritus", "Team Lead", "Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/CgHENoB.jpg",
   "linkedin": "https://www.linkedin.com/in/campbell-phalen",

--- a/src/json/alumni/cxlu.json
+++ b/src/json/alumni/cxlu.json
@@ -5,8 +5,12 @@
   "school": "Wharton,Engineering",
   "bio": "Big fan of short stories, hedgehogs, and horror. This semester I'm learning resin casting through Wharton Passion Projects - hit me up if you'd like to join!",
   "hometown": "Plano, TX",
-  "team": "Penn Clubs",
-  "roles": ["Front-End Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Front-End Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/3L2Qe4a.jpg",
   "linkedin": "https://www.linkedin.com/in/christina-lu-964235144/",
   "website": "",

--- a/src/json/alumni/david322.json
+++ b/src/json/alumni/david322.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Never skip bicep day.",
   "hometown": "Philadelphia, Pennsylvania",
-  "team": "Penn Clubs",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/VzjrF7g.jpeg",
   "linkedin": "",
   "website": "",

--- a/src/json/alumni/dfeng678.json
+++ b/src/json/alumni/dfeng678.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "",
   "hometown": "Albuquerque, New Mexico",
-  "team": "Penn Clubs",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/PHuZxIT.jpg",
   "linkedin": "https://www.linkedin.com/in/david-feng-8b601921b/",
   "website": "",
@@ -16,4 +20,3 @@
   "graduation_year": 2024,
   "job": null
 }
-  

--- a/src/json/alumni/dhaupt.json
+++ b/src/json/alumni/dhaupt.json
@@ -5,8 +5,12 @@
   "pennkey": "dhaupt",
   "bio": "I'm Team Lead for Penn Course Alert and Penn Course Plan. Outside of Labs and CS, I'm a space exploration enthusiast and politics junkie.",
   "hometown": "New York, NY",
-  "team": "Penn Courses",
-  "roles": ["Director Emeritus", "Team Lead", "Full Stack Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Director Emeritus", "Team Lead", "Full Stack Engineer"]
+    }
+  ],
   "photo": "https://avatars1.githubusercontent.com/u/436045?s=400&u=92519faf207e6f2ccc75df519ad89d9609a1aea4&v=4",
   "linkedin": "https://www.linkedin.com/in/davishaupt/",
   "website": "https://davi.sh/",

--- a/src/json/alumni/dlike.json
+++ b/src/json/alumni/dlike.json
@@ -5,8 +5,12 @@
   "pennkey": "dlike",
   "bio": "I'm a sophomore studying CIS from New Jersey. At Penn Labs, I'm working on Penn Course Plan. When I'm not coding, I enjoy biking and running.",
   "hometown": "East Brunswick, New Jersey",
-  "team": "Penn Courses",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/33gebgh.jpg",
   "linkedin": "https://www.linkedin.com/in/daniel-like-b18857133/",
   "website": null,

--- a/src/json/alumni/dng8000.json
+++ b/src/json/alumni/dng8000.json
@@ -5,10 +5,11 @@
   "pennkey": "dng8000",
   "bio": "Hi! I'm a Business Development Team Lead studying Computer Science and Finance. I’m interested in edtech, finance, and product management. Outside of Labs and Penn, I enjoy catching up on politics, eating new foods and exploring new places.",
   "hometown": "San Francisco Bay Area, CA",
-  "team": "Penn Courses",
-  "roles": [
-    "Team Lead",
-    "Business Developer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Team Lead", "Business Developer"]
+    }
   ],
   "photo": "https://s3.amazonaws.com/profilepictures.danielng.org/profilec.png",
   "linkedin": "https://www.linkedin.com/in/danielykng/",

--- a/src/json/alumni/dsalib.json
+++ b/src/json/alumni/dsalib.json
@@ -3,11 +3,13 @@
   "pennkey": "dsalib",
   "major": "Statistics + Data Science",
   "school": "Wharton,Engineering",
-  "bio": "Heyo\ud83e\udd20!  I'm Daniel and I am an iOS developer for Penn Mobile from Southern California! After switching majors countless times, I finally study Statistics and Data Science!",
+  "bio": "Heyo 🤠! I'm Daniel and I am an iOS developer for Penn Mobile from Southern California! After switching majors countless times, I finally study Statistics and Data Science!",
   "hometown": "Rancho Cucamonga, CA",
-  "team": "Penn Mobile",
-  "roles": [
-    "iOS Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/T09dRU6.jpg",
   "linkedin": "www.linkedin.com/in/dsalib",

--- a/src/json/alumni/dtao.json
+++ b/src/json/alumni/dtao.json
@@ -5,10 +5,11 @@
   "pennkey": "dtao",
   "bio": "I'm a freshman studying [hipster CS](https://www.nets.upenn.edu/). I know a little too much about Japanese rhythm games. I think the harrier jump jet is overrated, especially compared to stairs.",
   "hometown": "Chicago, IL",
-  "team": "Penn Courses",
-  "roles": [
-    "Team Lead",
-    "Full Stack Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Team Lead", "Full Stack Engineer"]
+    }
   ],
   "photo": "https://danxtao.com/assets/headshot.jpg",
   "linkedin": "https://www.linkedin.com/in/xdtao/",

--- a/src/json/alumni/elisaz.json
+++ b/src/json/alumni/elisaz.json
@@ -5,8 +5,12 @@
   "school": "Wharton",
   "bio": "Hi! I'm Elisa, a student in Wharton. Big fan of yelp-ing and drinking iced oat milk lattes.",
   "hometown": "San Jose, CA",
-  "team": "Penn Mobile",
-  "roles": ["Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Business Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/VF5rtns.jpg",
   "linkedin": "https://www.linkedin.com/in/elisa-zhang/",
   "website": "",

--- a/src/json/alumni/evakill.json
+++ b/src/json/alumni/evakill.json
@@ -5,8 +5,12 @@
   "pennkey": "evakill",
   "bio": "labs OG athletic director, react animation god, has own slack channel #eva",
   "hometown": "Little Compton, Rhode Island",
-  "team": "Penn Clubs",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/v1IkXXK.jpg",
   "linkedin": null,
   "website": null,

--- a/src/json/alumni/ezwang.json
+++ b/src/json/alumni/ezwang.json
@@ -5,14 +5,18 @@
   "pennkey": "ezwang",
   "bio": "Hello!",
   "hometown": "Lorton, VA",
-  "team": "Penn Clubs",
-  "roles": ["Team Lead", "Backend Engineer", "Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Team Lead", "Backend Engineer", "Frontend Engineer"]
+    }
+  ],
   "photo": "https://avatars1.githubusercontent.com/u/4441174?s=460&v=4",
   "linkedin": null,
   "website": null,
   "github": "https://github.com/ezwang",
   "semester_joined": "2017C",
-  "alumnus": false,
-  "graduation_year": null,
+  "alumnus": true,
+  "graduation_year": 2021,
   "job": null
 }

--- a/src/json/alumni/gautam1.json
+++ b/src/json/alumni/gautam1.json
@@ -5,9 +5,11 @@
   "school": "Engineering & Wharton",
   "bio": "I'm a sophomore studying CIS and Statistics from New Jersey. In my free time, I like playing squash and making music.",
   "hometown": "Princeton Junction, NJ",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/xTKyDWE.jpg",
   "linkedin": "https://www.linkedin.com/in/gautam-ramesh-b9693179/",

--- a/src/json/alumni/hammoudh.json
+++ b/src/json/alumni/hammoudh.json
@@ -5,11 +5,11 @@
   "pennkey": "hammoudh",
   "bio": "Hey! I'm Hassan and I'm one of the Penn Mobile Portal team leads. I also work on Biz Dev for Penn Mobile. I love talking about sports, literature, data science, math, and really anything that can teach me something! I'm currently studying Finance and Statistics in Wharton with a minor in Mathematics. Feel free to strike up a conversation with me about my work or anything else!",
   "hometown": "Dearborn, MI",
-  "team": "Penn Mobile",
-  "roles": [
-    "Director Emeritus",
-    "Team Lead",
-    "Business Developer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Director Emeritus", "Team Lead", "Business Developer"]
+    }
   ],
   "photo": "https://i.imgur.com/sS6y8Xb.jpg",
   "linkedin": "https://www.linkedin.com/in/hassan-hammoud/",

--- a/src/json/alumni/hdominic.json
+++ b/src/json/alumni/hdominic.json
@@ -1,22 +1,22 @@
 {
-  "name": "Hassan Hammoud",
-  "major": "Finance + Statistics",
-  "school": "Wharton",
-  "pennkey": "hammoudh",
-  "bio": "Hey! I'm Hassan and I'm one of the Penn Mobile Portal team leads. I also work on Biz Dev for Penn Mobile. I love talking about sports, literature, data science, math, and really anything that can teach me something! I'm currently studying Finance and Statistics in Wharton with a minor in Mathematics. Feel free to strike up a conversation with me about my work or anything else!",
-  "hometown": "Dearborn, MI",
+  "name": "Dominic Holmes",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "pennkey": "hdominic",
+  "bio": "I'm an iOS developer and product designer from the midwest! I <3 Penn Mobile",
+  "hometown": "Dell Rapids, SD",
   "teamRoles": [
     {
       "team": "Penn Mobile",
-      "roles": ["Director Emeritus", "Team Lead", "Business Developer"]
+      "roles": ["Team Lead", "iOS Mobile Engineer", "Director Emeritus"]
     }
   ],
-  "photo": "https://i.imgur.com/sS6y8Xb.jpg",
-  "linkedin": "https://www.linkedin.com/in/hassan-hammoud/",
-  "website": null,
-  "github": null,
-  "semester_joined": "2019C",
+  "photo": "https://github.com/DominicHolmes/profile-picture/blob/master/dominic.jpeg?raw=true",
+  "linkedin": "https://www.linkedin.com/in/dominic-holmes-21b612133/",
+  "website": "https://dominic.land",
+  "github": "https://github.com/DominicHolmes",
+  "semester_joined": "2017C",
   "alumnus": true,
-  "graduation_year": 2023,
+  "graduation_year": 2020,
   "job": null
 }

--- a/src/json/alumni/hdominic.json
+++ b/src/json/alumni/hdominic.json
@@ -1,22 +1,22 @@
 {
-  "name": "Dominic Holmes",
-  "major": "Computer Science",
-  "school": "Engineering",
-  "pennkey": "hdominic",
-  "bio": "I'm an iOS developer and product designer from the midwest! I <3 Penn Mobile",
-  "hometown": "Dell Rapids, SD",
-  "team": "Penn Mobile",
-  "roles": [
-    "Team Lead",
-    "iOS Mobile Engineer",
-    "Director Emeritus"
+  "name": "Hassan Hammoud",
+  "major": "Finance + Statistics",
+  "school": "Wharton",
+  "pennkey": "hammoudh",
+  "bio": "Hey! I'm Hassan and I'm one of the Penn Mobile Portal team leads. I also work on Biz Dev for Penn Mobile. I love talking about sports, literature, data science, math, and really anything that can teach me something! I'm currently studying Finance and Statistics in Wharton with a minor in Mathematics. Feel free to strike up a conversation with me about my work or anything else!",
+  "hometown": "Dearborn, MI",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Director Emeritus", "Team Lead", "Business Developer"]
+    }
   ],
-  "photo": "https://github.com/DominicHolmes/profile-picture/blob/master/dominic.jpeg?raw=true",
-  "linkedin": "https://www.linkedin.com/in/dominic-holmes-21b612133/",
-  "website": "https://dominic.land",
-  "github": "https://github.com/DominicHolmes",
-  "semester_joined": "2017C",
+  "photo": "https://i.imgur.com/sS6y8Xb.jpg",
+  "linkedin": "https://www.linkedin.com/in/hassan-hammoud/",
+  "website": null,
+  "github": null,
+  "semester_joined": "2019C",
   "alumnus": true,
-  "graduation_year": 2020,
+  "graduation_year": 2023,
   "job": null
 }

--- a/src/json/alumni/healice.json
+++ b/src/json/alumni/healice.json
@@ -1,20 +1,22 @@
 {
-  "name": "Alice He",
-  "pennkey": "healice",
+  "name": "Dominic Holmes",
   "major": "Computer Science",
   "school": "Engineering",
-  "bio": "Passionate about the intersection of art and technology, architecture, and Money Heist. Budding college dorm chef. Pesto and hot sauce lover. :P",
-  "hometown": "Washington, DC",
-  "team": "Penn Clubs",
-  "roles": [
-    "Designer"
+  "pennkey": "hdominic",
+  "bio": "I'm an iOS developer and product designer from the midwest! I <3 Penn Mobile",
+  "hometown": "Dell Rapids, SD",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Team Lead", "iOS Mobile Engineer", "Director Emeritus"]
+    }
   ],
-  "photo": "https://i.imgur.com/uuYavDm.jpg",
-  "linkedin": "https://www.linkedin.com/in/alicezhe/",
-  "website": "https://alicezhe.github.com/",
-  "github": "https://github.com/alicezhe",
-  "semester_joined": "2020C",
+  "photo": "https://github.com/DominicHolmes/profile-picture/blob/master/dominic.jpeg?raw=true",
+  "linkedin": "https://www.linkedin.com/in/dominic-holmes-21b612133/",
+  "website": "https://dominic.land",
+  "github": "https://github.com/DominicHolmes",
+  "semester_joined": "2017C",
   "alumnus": true,
-  "graduation_year": 2023,
+  "graduation_year": 2020,
   "job": null
 }

--- a/src/json/alumni/healice.json
+++ b/src/json/alumni/healice.json
@@ -1,22 +1,22 @@
 {
-  "name": "Dominic Holmes",
+  "name": "Alice He",
+  "pennkey": "healice",
   "major": "Computer Science",
   "school": "Engineering",
-  "pennkey": "hdominic",
-  "bio": "I'm an iOS developer and product designer from the midwest! I <3 Penn Mobile",
-  "hometown": "Dell Rapids, SD",
+  "bio": "Passionate about the intersection of art and technology, architecture, and Money Heist. Budding college dorm chef. Pesto and hot sauce lover. :P",
+  "hometown": "Washington, DC",
   "teamRoles": [
     {
-      "team": "Penn Mobile",
-      "roles": ["Team Lead", "iOS Mobile Engineer", "Director Emeritus"]
+      "team": "Penn Clubs",
+      "roles": ["Designer"]
     }
   ],
-  "photo": "https://github.com/DominicHolmes/profile-picture/blob/master/dominic.jpeg?raw=true",
-  "linkedin": "https://www.linkedin.com/in/dominic-holmes-21b612133/",
-  "website": "https://dominic.land",
-  "github": "https://github.com/DominicHolmes",
-  "semester_joined": "2017C",
+  "photo": "https://i.imgur.com/uuYavDm.jpg",
+  "linkedin": "https://www.linkedin.com/in/alicezhe/",
+  "website": "https://alicezhe.github.com/",
+  "github": "https://github.com/alicezhe",
+  "semester_joined": "2020C",
   "alumnus": true,
-  "graduation_year": 2020,
+  "graduation_year": 2023,
   "job": null
 }

--- a/src/json/alumni/huangl24.json
+++ b/src/json/alumni/huangl24.json
@@ -1,22 +1,22 @@
 {
-  "name": "Alice He",
-  "pennkey": "healice",
+  "name": "Larry Huang",
+  "pennkey": "huangl24",
   "major": "Computer Science",
   "school": "Engineering",
-  "bio": "Passionate about the intersection of art and technology, architecture, and Money Heist. Budding college dorm chef. Pesto and hot sauce lover. :P",
-  "hometown": "Washington, DC",
+  "bio": "Hi, I am Larry and I like to code.",
+  "hometown": "Wilton, Connecticut",
   "teamRoles": [
     {
-      "team": "Penn Clubs",
-      "roles": ["Designer"]
+      "team": "Office Hours Queue",
+      "roles": ["Frontend Engineer"]
     }
   ],
-  "photo": "https://i.imgur.com/uuYavDm.jpg",
-  "linkedin": "https://www.linkedin.com/in/alicezhe/",
-  "website": "https://alicezhe.github.com/",
-  "github": "https://github.com/alicezhe",
-  "semester_joined": "2020C",
+  "photo": "https://i.imgur.com/WN2Znez.jpg",
+  "linkedin": "https://www.linkedin.com/in/larryjhuang/",
+  "website": "",
+  "github": "https://github.com/lhuang19",
+  "semester_joined": "2021A",
   "alumnus": true,
-  "graduation_year": 2023,
+  "graduation_year": 2024,
   "job": null
 }

--- a/src/json/alumni/huangl24.json
+++ b/src/json/alumni/huangl24.json
@@ -1,18 +1,22 @@
 {
-  "name": "Larry Huang",
-  "pennkey": "huangl24",
+  "name": "Alice He",
+  "pennkey": "healice",
   "major": "Computer Science",
   "school": "Engineering",
-  "bio": "Hi, I am Larry and I like to code.",
-  "hometown": "Wilton, Connecticut",
-  "team": "Office Hours Queue",
-  "roles": ["Frontend Engineer"],
-  "photo": "https://i.imgur.com/WN2Znez.jpg",
-  "linkedin": "https://www.linkedin.com/in/larryjhuang/",
-  "website": "",
-  "github": "https://github.com/lhuang19",
-  "semester_joined": "2021A",
+  "bio": "Passionate about the intersection of art and technology, architecture, and Money Heist. Budding college dorm chef. Pesto and hot sauce lover. :P",
+  "hometown": "Washington, DC",
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Designer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/uuYavDm.jpg",
+  "linkedin": "https://www.linkedin.com/in/alicezhe/",
+  "website": "https://alicezhe.github.com/",
+  "github": "https://github.com/alicezhe",
+  "semester_joined": "2020C",
   "alumnus": true,
-  "graduation_year": 2024,
+  "graduation_year": 2023,
   "job": null
 }

--- a/src/json/alumni/huhelen.json
+++ b/src/json/alumni/huhelen.json
@@ -4,8 +4,12 @@
   "major": "Finance and Business Analytics",
   "school": "Wharton",
   "bio": "Hi! My name’s Helen, and I’m a sophomore at Wharton. Outside of Labs, I love going on coffee dates, exploring farmer’s markets, and casually hiking at national parks. Nice to meet you!",
-  "team": "Penn Clubs",
-  "roles": ["Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Business Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/0pe8d1A.jpeg",
   "linkedin": "https://www.linkedin.com/in/helentianhu/",
   "website": "",

--- a/src/json/alumni/jaredmit.json
+++ b/src/json/alumni/jaredmit.json
@@ -4,8 +4,12 @@
   "major": "Communication: Data and Network Science",
   "school": "College",
   "bio": "Hi! I'm Jared. I'm a junior from New Jersey studying Communication with minors in Data Science and Consumer Psychology.",
-  "team": "Penn Mobile",
-  "roles": ["Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Business Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/aSQadYM.jpeg",
   "linkedin": "https://www.linkedin.com/in/jared-mitovich/",
   "website": "https://www.jared-mitovich.com/",

--- a/src/json/alumni/jayvish.json
+++ b/src/json/alumni/jayvish.json
@@ -5,8 +5,12 @@
   "school": "SEAS",
   "bio": "Freshman in NETS working on the platform team! Hit me up if you want to play ping pong!",
   "hometown": "Santa Clara, CA",
-  "team": "Platform",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/Nsygmq9.jpg",
   "linkedin": "https://www.linkedin.com/in/jay-vishwarupe-72a999155/",
   "website": "",

--- a/src/json/alumni/jcao3.json
+++ b/src/json/alumni/jcao3.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "big fan of popcorn, hiking, and penguins :)",
   "hometown": "State College, PA",
-  "team": "Penn Mobile",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/YMUr2Nb.jpg",
   "linkedin": "https://linkedin.com/in/jasminecao",

--- a/src/json/alumni/jkao97.json
+++ b/src/json/alumni/jkao97.json
@@ -5,9 +5,11 @@
   "school": "Engineering & Wharton",
   "bio": "Hi, I'm Jonathan! Learning how to DevOps.",
   "hometown": "Palo Alto, CA",
-  "team": "Platform",
-  "roles": [
-    "DevOps"
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
   ],
   "photo": "https://i.imgur.com/7PcOkIX.jpg",
   "linkedin": "https://www.linkedin.com/in/jonathan-kao-640139166/",

--- a/src/json/alumni/jongmin.json
+++ b/src/json/alumni/jongmin.json
@@ -5,10 +5,11 @@
   "school": "Engineering & Wharton",
   "bio": "Hello, I'm a Korean iOS developer from Hong Kong. In my free time, I love to practice close-up card magic.",
   "hometown": "Hong Kong/Seoul",
-  "team": "Penn Mobile",
-  "roles": [
-    "Team Lead",
-    "iOS Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Team Lead", "iOS Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/4xw5g6G.jpg",
   "linkedin": "http://www.linkedin.com/in/jong-min-choi",

--- a/src/json/alumni/joshdo.json
+++ b/src/json/alumni/joshdo.json
@@ -5,12 +5,11 @@
   "pennkey": "joshdo",
   "bio": "Hi! I'm an iOS and backend engineer, a Penn Mobile team lead, and a former Penn Labs director. Outside of Labs, I love playing tennis, going on hikes, and following space exploration. Penn Labs 4 life!.",
   "hometown": "Atlanta, GA",
-  "team": "Penn Mobile",
-  "roles": [
-    "Team Lead",
-    "iOS Engineer",
-    "Backend Engineer",
-    "Director Emeritus"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Team Lead", "iOS Engineer", "Backend Engineer", "Director Emeritus"]
+    }
   ],
   "photo": "https://i.imgur.com/bNUrz8V.jpg",
   "linkedin": "https://www.linkedin.com/in/joshdoman/",

--- a/src/json/alumni/jtlieb.json
+++ b/src/json/alumni/jtlieb.json
@@ -5,9 +5,11 @@
   "pennkey": "jtlieb",
   "bio": "I'm a Computer Science student that likes to yoyo and eat Buffalo Wing Pringles in my free time.",
   "hometown": "Camarillo, CA",
-  "team": "Penn Mobile",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/5HXWOJw.jpg",
   "linkedin": "http://linkedin.com/in/lieb",

--- a/src/json/alumni/jweiner1.json
+++ b/src/json/alumni/jweiner1.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Josh was born and raised in New York, where he attended Stuyvesant High School and promptly fell in love with computer science. Passionate about everything from international relations to architecture to fried chicken, he's always excited to tackle whatever challenge lies ahead.",
   "hometown": "New York, NY",
-  "team": "Penn Mobile",
-  "roles": [
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/V4RclNb.png",
   "linkedin": "linkedin.com/in/joshuamaxweiner/",

--- a/src/json/alumni/jxiao23.json
+++ b/src/json/alumni/jxiao23.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi! I'm a junior studying CIS from Northern Jersey, and I'm a part of the Courses team. When I'm not coding, you can probably find me binging YouTube or playing League.",
   "hometown": "Warren, NJ",
-  "team": "Penn Courses",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/Ms5bqCc.jpg",
   "linkedin": "https://www.linkedin.com/in/jeffrey-xiao/",
   "website": "http://jeffreyxiao.com/",

--- a/src/json/alumni/jytan.json
+++ b/src/json/alumni/jytan.json
@@ -5,10 +5,11 @@
   "pennkey": "jytan",
   "bio": "passionate about experience design, life sciences, and behavioral psychology.",
   "hometown": "Cheshire, CT",
-  "team": "Penn Courses",
-  "roles": [
-    "Team Lead",
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Team Lead", "Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/gQOJTqr.jpg",
   "linkedin": "https://www.linkedin.com/in/jesstan4/",

--- a/src/json/alumni/karenyen.json
+++ b/src/json/alumni/karenyen.json
@@ -4,10 +4,12 @@
   "major": "Computer Science & Business",
   "school": "Engineering & Wharton",
   "bio": "Hi! I'm a sophomore from the Bay Area and Taiwan. I'm obsessed with cute cafes, cats, and electronic music. You can always find me sipping on boba/iced coffee! :)",
-  "hometown": "Fremont, California ",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Business Developer"
+  "hometown": "Fremont, California",
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Business Developer"]
+    }
   ],
   "photo": "https://i.imgur.com/djfiXv9.jpg",
   "linkedin": "https://www.linkedin.com/in/karenyen27/",

--- a/src/json/alumni/kevc528.json
+++ b/src/json/alumni/kevc528.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hello! I'm a sophomore from Minnesota studying Computer Science and I'm a backend engineer for OHQ. In my free time I enjoy playing tennis and chilling with friends.",
   "hometown": "Woodbury, MN",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/IwB6Ywu.jpg",
   "linkedin": "https://www.linkedin.com/in/kevc528/",

--- a/src/json/alumni/kiruba.json
+++ b/src/json/alumni/kiruba.json
@@ -3,10 +3,14 @@
   "major": "Computer Science + Cognitive Science",
   "school": "College & Engineering",
   "pennkey": "kiruba",
-  "bio": "Hey there, I'm Arun and I'm currently leading efforts in data science and people management. Previously, I was the team lead for Platform and Penn Clubs! Outside of Penn Labs I also research machine learning in Penn's [NLP Group](http://penn-nlp.github.io/) and I teach CIS 192 (Python) at Penn. Other than that, I like skateboarding,  brewing coffee, and watching cartoons!",
+  "bio": "Hey there, I'm Arun and I'm currently leading efforts in data science and people management. Previously, I was the team lead for Platform and Penn Clubs! Outside of Penn Labs I also research machine learning in Penn's [NLP Group](http://penn-nlp.github.io/) and I teach CIS 192 (Python) at Penn. Other than that, I like skateboarding, brewing coffee, and watching cartoons!",
   "hometown": "Mississauga, Canada",
-  "team": "Platform",
-  "roles": ["Backend Engineer", "Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Backend Engineer", "Business Developer"]
+    }
+  ],
   "photo": "https://avatars2.githubusercontent.com/u/6424868?s=400&u=481199032fa2426a9c4bb60dcb937966cd8c3ce0&v=4",
   "linkedin": "https://www.linkedin.com/in/arunkirubarajan/",
   "website": "https://kirubarajan.com",

--- a/src/json/alumni/krema.json
+++ b/src/json/alumni/krema.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Catch me either pretending to code or excessively playing FIFA Ultimate Team... or making banana bread.",
   "hometown": "Cairo, Egypt",
-  "team": "Penn Mobile",
-  "roles": [
-    "Android Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/lT1Xivj.jpeg",
   "linkedin": "https://www.linkedin.com/in/ali-krema/",

--- a/src/json/alumni/ksai.json
+++ b/src/json/alumni/ksai.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hey, my name is Karthik. I'm a freshman majoring in Computer Science. Outside of Labs, I'm a national chess master and love watching sports, especially basketball and football!",
   "hometown": "Minneapolis, MN",
-  "team": "Penn Mobile",
-  "roles": ["iOS Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/5eFjYmk.jpeg",
   "linkedin": "https://www.linkedin.com/in/kspadman/",
   "website": null,

--- a/src/json/alumni/kwokhui.json
+++ b/src/json/alumni/kwokhui.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hi, My name is Kelvin and I am a Frontend Engineer for Penn Clubs.",
   "hometown": "Hong Kong",
-  "team": "Penn Clubs",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/FjcGTEe.jpg",
   "linkedin": "",

--- a/src/json/alumni/lanting.json
+++ b/src/json/alumni/lanting.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Love CIS, love learning about new tech, love bubble tea",
   "hometown": "Taipei, Taiwan",
-  "team": "Platform",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/6tLGUQm.jpg",
   "linkedin": "www.linkedin.com/in/lantingchiang",
   "website": "",

--- a/src/json/alumni/laurlee.json
+++ b/src/json/alumni/laurlee.json
@@ -3,11 +3,13 @@
   "pennkey": "laurlee",
   "major": "Computer Science",
   "school": "Engineering",
-  "bio": "I'm a frontend developer who loves fruit ",
+  "bio": "I'm a frontend developer who loves fruit",
   "hometown": "Hong Kong/Seoul",
-  "team": "Penn Courses",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/iqYpWa1.jpg",
   "linkedin": "https://www.linkedin.com/in/laurel-lee-74103916b/",

--- a/src/json/alumni/lstting.json
+++ b/src/json/alumni/lstting.json
@@ -5,9 +5,11 @@
   "pennkey": "lstting",
   "bio": "likes cats, drawing, and finding new music",
   "hometown": "Holmdel, NJ",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/EkkYCEq.jpg",
   "linkedin": "https://www.linkedin.com/in/lindating",

--- a/src/json/alumni/lujerry.json
+++ b/src/json/alumni/lujerry.json
@@ -3,10 +3,14 @@
   "major": "Computer Science + Cognitive Science",
   "school": "College & Engineering",
   "pennkey": "lujerry",
-  "bio": "I'm a sophomore studying computer science and cognitive science. I work on [Penn Course Review](https://penncoursereview.com).  I like linguistics and natural language processing.",
+  "bio": "I'm a sophomore studying computer science and cognitive science. I work on [Penn Course Review](https://penncoursereview.com). I like linguistics and natural language processing.",
   "hometown": "Nashville, TN",
-  "team": "Penn Courses",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://avatars3.githubusercontent.com/u/35176284?s=460&v=4",
   "linkedin": null,
   "website": null,

--- a/src/json/alumni/marcoc.json
+++ b/src/json/alumni/marcoc.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hi! I'm on the OHQ team working on the backend. In my spare time, you can find me listening to psychology/economics/true crime podcasts and cheering on my hometown Vancouver Canucks!",
   "hometown": "Vancouver, BC",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/xRB3NmM.jpg?2",
   "linkedin": "https://www.linkedin.com/in/marco-chan/",

--- a/src/json/alumni/martagf.json
+++ b/src/json/alumni/martagf.json
@@ -5,8 +5,12 @@
   "pennkey": "martagf",
   "bio": "Hi! I'm an Android developer (<3 Penn Mobile) from Spain, currently studying CIS at Penn. On a usual day, you can find me complaining about the Fahrenheit scale, coding, reading, or pretending to work out by sitting at the gym watching Netflix. I also love art, exploring new places and good food.",
   "hometown": "Santiago de Compostela, Spain",
-  "team": "Penn Mobile",
-  "roles": ["Director Emeritus", "Team Lead", "Android Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Director Emeritus", "Team Lead", "Android Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/HdLTlAU.jpg",
   "linkedin": "https://www.linkedin.com/in/marta-garcia-ferreiro/",
   "website": null,

--- a/src/json/alumni/mattrh.json
+++ b/src/json/alumni/mattrh.json
@@ -5,8 +5,12 @@
   "school": "Engineering & Wharton",
   "bio": "Hey! I'm a team lead and full stack engineer working on Penn Mobile Portal. My passions include understanding obscure blockchain applications and building products that people love. In my free time, you can usually find me listening to music, learning something new, or trying a new restaurant in Philly!",
   "hometown": "Houston, TX",
-  "team": "Penn Mobile",
-  "roles": ["Team Lead", "Full Stack Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Team Lead", "Full Stack Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/JciQvbb.jpg",
   "linkedin": "https://www.linkedin.com/in/matthew-rosca-halmagean/",
   "website": "",

--- a/src/json/alumni/mistyl.json
+++ b/src/json/alumni/mistyl.json
@@ -5,11 +5,11 @@
   "pennkey": "mistysl",
   "bio": "Hi there! My name's Misty and I'm a rising senior at Wharton. Outside of Penn Labs, I love karaoking, snowboarding, and exploring Philly cafes. Hit me up if you want to talk anything music, reading, or coffee!",
   "hometown": "Seattle, WA",
-  "team": "Penn Clubs",
-  "roles": [
-    "Director Emeritus",
-    "Team Lead",
-    "Business Developer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Director Emeritus", "Team Lead", "Business Developer"]
+    }
   ],
   "photo": "https://i.imgur.com/Cv5wSt2.jpg",
   "linkedin": "https://linkedin.com/in/misty-liao",

--- a/src/json/alumni/mtsiang.json
+++ b/src/json/alumni/mtsiang.json
@@ -3,11 +3,13 @@
   "pennkey": "mtsiang",
   "major": "CIS",
   "school": "Engineering",
-  "bio": "Since I'm in Engineering, I don't have a lot of free time. But when I do, I like playing basketball or jamming with friends. ",
+  "bio": "Since I'm in Engineering, I don't have a lot of free time. But when I do, I like playing basketball or jamming with friends.",
   "hometown": "Shanghai",
-  "team": "Penn Clubs",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/V4RclNb.png",
   "linkedin": "linkedin.com/in/maxtsiang",

--- a/src/json/alumni/nerone.json
+++ b/src/json/alumni/nerone.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Oi! I'm a junior studying Computer Science. In my free time, I like to play Counter Strike, learn new technologies, and strum random things on the guitar.",
   "hometown": "Guarapuava, Brazil",
-  "team": "Penn Mobile",
-  "roles": [
-    "Android Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/vGfLyyp.jpg",
   "linkedin": "https://www.linkedin.com/in/leonardo-felipe-nerone/",

--- a/src/json/alumni/njcorona.json
+++ b/src/json/alumni/njcorona.json
@@ -3,11 +3,13 @@
   "major": "Business Analytics",
   "school": "Wharton",
   "pennkey": "njcorona",
-  "bio": "Hi, I'm Nicolas! I'm a senior, and I'm excited to make the most out of my final year at Penn through Penn Labs as a Business Developer for [OHQ](https://pennlabs.org/products/office-hours-queue).   If you want to learn more about me, check out [my website](https://nicolascorona.com/)!",
+  "bio": "Hi, I'm Nicolas! I'm a senior, and I'm excited to make the most out of my final year at Penn through Penn Labs as a Business Developer for [OHQ](https://pennlabs.org/products/office-hours-queue). If you want to learn more about me, check out [my website](https://nicolascorona.com/)!",
   "hometown": "Baltimore, MD",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Business Developer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Business Developer"]
+    }
   ],
   "photo": "https://i.imgur.com/bo13cZx.png",
   "linkedin": "https://www.linkedin.com/in/njcorona/",

--- a/src/json/alumni/pawalt.json
+++ b/src/json/alumni/pawalt.json
@@ -5,8 +5,12 @@
   "pennkey": "pawalt",
   "bio": "Hey y'all, I'm Peyton, and I'm currently working on [infrastructure](https://github.com/pennlabs/infrastructure) for Labs. Outside of Labs, I'm an instructor for [CIS 188](https://cis188.org/). If I'm not doing those things, I'm probably skiing or hiking!",
   "hometown": "Richmond, VA",
-  "team": "Platform",
-  "roles": ["DevOps"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
+  ],
   "photo": "https://pawa.lt/img/avatar.jpg",
   "linkedin": "https://www.linkedin.com/in/peyton-walters-a26559158/",
   "website": "https://pawa.lt/",

--- a/src/json/alumni/pulkith.json
+++ b/src/json/alumni/pulkith.json
@@ -1,19 +1,22 @@
 {
-    "name": "Pulkith Paruchuri",
-    "pennkey": "pulkith",
-    "major": "Computer Science & Statistics",
-    "school": "Engineering & Wharton",
-    "bio": "Howdy! I enjoy building (and especially, breaking) things.",
-    "hometown": "Frisco, TX",
-    "team": "Penn Mobile",
-    "roles": ["iOS Mobile Engineer"],
-    "photo": "https://i.imgur.com/X79uZK1.jpg",
-    "linkedin": "https://www.linkedin.com/in/pulkith",
-    "website": "https://pulkith.com",
-    "github": "https://github.com/DespicableMonkey",
-    "semester_joined": "2023C",
-    "alumnus": false,
-    "graduation_year": 2027,
-    "job": null
-  }
-  
+  "name": "Pulkith Paruchuri",
+  "pennkey": "pulkith",
+  "major": "Computer Science & Statistics",
+  "school": "Engineering & Wharton",
+  "bio": "Howdy! I enjoy building (and especially, breaking) things.",
+  "hometown": "Frisco, TX",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/X79uZK1.jpg",
+  "linkedin": "https://www.linkedin.com/in/pulkith",
+  "website": "https://pulkith.com",
+  "github": "https://github.com/DespicableMonkey",
+  "semester_joined": "2023C",
+  "alumnus": false,
+  "graduation_year": 2027,
+  "job": null
+}

--- a/src/json/alumni/raunaqs.json
+++ b/src/json/alumni/raunaqs.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Yo! I'm a CS student interested in ~socially beneficial~ technology. In my spare time, I enjoy watching Netflix, playing guitar, and watching football. GO BIRDS!",
   "hometown": "Philadelphia, PA",
-  "team": "Penn Mobile",
-  "roles": ["iOS Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/3OEHNEn.jpeg",
   "linkedin": "https://www.linkedin.com/in/raunaq-singh-2024/",
   "website": "",

--- a/src/json/alumni/rmarques.json
+++ b/src/json/alumni/rmarques.json
@@ -5,9 +5,11 @@
   "pennkey": "rmarques",
   "bio": "Likes to think he can code. Sometimes manages to actually code.",
   "hometown": "Rio de Janeiro, Brazil",
-  "team": "Platform",
-  "roles": [
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/6w1POGI.jpg",
   "linkedin": "https://www.linkedin.com/in/rafael-c-marques/",

--- a/src/json/alumni/sahitpen.json
+++ b/src/json/alumni/sahitpen.json
@@ -5,9 +5,11 @@
   "school": "Engineering & Wharton",
   "bio": "Hey! I'm a sophomore studying Computer Science and Finance. In my free time, I love producing videos, going on runs, and binging Netflix.",
   "hometown": "Plainsboro, NJ",
-  "team": "Penn Mobile",
-  "roles": [
-    "Android Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/SF8C4e8.jpg",
   "linkedin": "https://www.linkedin.com/in/sahit-p-bb7939107/",

--- a/src/json/alumni/sharkuo.json
+++ b/src/json/alumni/sharkuo.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Big fan of indomie, sweatpants, and art/design.",
   "hometown": "Taipei, Taiwan",
-  "team": "Penn Clubs",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/W9x6a1V.jpg",
   "linkedin": "https://www.linkedin.com/in/sharon-kuo-63a90018b/",

--- a/src/json/alumni/shayaz.json
+++ b/src/json/alumni/shayaz.json
@@ -2,12 +2,14 @@
   "name": "Shaya Zarkesh",
   "pennkey": "shayaz",
   "major": "Computer Science + Markting",
-  "school": "Engineering,Wharton",
+  "school": "Engineering, Wharton",
   "bio": "Hi! I'm Shaya. I'm a sophomore from Saratoga, CA, and I study Computer Science and Business. I do a lot of frontend web development and UX design, both for Labs and an education startup I've been working on. Outside of Labs and class, you can find me on the soccer field or playing FIFA with friends.",
   "hometown": "Saratoga, CA",
-  "team": "Penn Courses",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/gNpdtAx.jpg",
   "linkedin": "https://www.linkedin.com/in/shaya-z-1042729a/",

--- a/src/json/alumni/sheriep.json
+++ b/src/json/alumni/sheriep.json
@@ -5,9 +5,11 @@
   "school": "College of Arts & Sciences",
   "bio": "Dreaming about going for a swim at the beach, hanging out with the watermelon birds, and having an endless supply of mangoes.",
   "hometown": "Sydney, Australia",
-  "team": "Penn Mobile",
-  "roles": [
-    "Business Developer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Business Developer"]
+    }
   ],
   "photo": "https://imgur.com/lj0H2OZ.jpg",
   "linkedin": "https://www.linkedin.com/in/sherie-pan/",

--- a/src/json/alumni/singhvik.json
+++ b/src/json/alumni/singhvik.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "coffee addict, mediocre tennis player, insecure coder.",
   "hometown": "Hong Kong",
-  "team": "Platform",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/e9i9TRn.jpg",
   "linkedin": "https://www.linkedin.com/in/vikram-singh-2002/",
   "github": "https://github.com/vsingh18567",

--- a/src/json/alumni/smlee18.json
+++ b/src/json/alumni/smlee18.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Sam has always been fascinated by the intersection of art and technology and . When she's not studying for CIS she enjoys drawing on her iPad, cooking, and watching Survivor!",
   "hometown": "Bryn Mawr",
-  "team": "Office Hours Queue",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/N9iwE0t.png",
   "linkedin": "https://www.linkedin.com/in/samantha-lee-1a5a5b172/",

--- a/src/json/alumni/snie.json
+++ b/src/json/alumni/snie.json
@@ -5,10 +5,11 @@
   "pennkey": "snie",
   "bio": "A lover of Akzidenz-Grotesk, #E62B1E, and Magic Carpet",
   "hometown": "The Hague, The Netherlands",
-  "team": "Penn Clubs",
-  "roles": [
-    "Team Lead",
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Team Lead", "Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/puZ1J6e.jpg",
   "linkedin": "https://www.linkedin.com/in/selina-nie-8aa67a145/",

--- a/src/json/alumni/sophiaye.json
+++ b/src/json/alumni/sophiaye.json
@@ -5,9 +5,11 @@
   "pennkey": "sophiaye",
   "bio": "I'm an aspiring UI/UX designer with an interest in web development and data science. I want to use technology to better create and enhance connections between people.",
   "hometown": "Newtown, PA",
-  "team": "Penn Mobile",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/rIe9M74.jpg",
   "linkedin": null,

--- a/src/json/alumni/sophiech.json
+++ b/src/json/alumni/sophiech.json
@@ -5,9 +5,11 @@
   "school": "College of Arts and Science",
   "bio": "bean juice lover. sometimes codes, sometimes designs.",
   "hometown": "Hangzhou, China",
-  "team": "Penn Mobile",
-  "roles": [
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/4hAxBGZ.jpg",
   "linkedin": "https://www.linkedin.com/in/sophienchen/",

--- a/src/json/alumni/szhang25.json
+++ b/src/json/alumni/szhang25.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi, I'm Susan! I'm studying CS in engineering and outside of coding, I enjoy trying different boba stores, watching animes, and taking walks.",
   "hometown": "Dallas, Texas/Shenzhen, China",
-  "team": "Penn Courses",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/yARr9Dv.png",
   "linkedin": "https://www.linkedin.com/in/lingzi-susan-zhang/",
   "website": "https://lingzi-susan-zhang.web.app/",
@@ -16,4 +20,3 @@
   "graduation_year": 2025,
   "job": null
 }
- 

--- a/src/json/alumni/tifchang.json
+++ b/src/json/alumni/tifchang.json
@@ -4,12 +4,17 @@
   "school": "Wharton",
   "pennkey": "tifchang",
   "hometown": "Honolulu, HI",
-  "team": "Directors",
-  "roles": ["Designer", "Director Emeritus"],
+  "teamRoles": [
+    {
+      "team": "Directors",
+      "roles": ["Designer", "Director Emeritus"]
+    }
+  ],
   "photo": "https://i.imgur.com/wDkP3rs.jpg",
   "linkedin": "https://www.linkedin.com/in/tobaccowallaa/",
   "website": "https://armaan.tobaccowalla.com",
   "github": "https://github.com/ArmaanT",
+  "semester_joined": null,
   "alumnus": true,
   "graduation_year": null,
   "job": null

--- a/src/json/alumni/tlshaw.json
+++ b/src/json/alumni/tlshaw.json
@@ -5,8 +5,12 @@
   "school": "College of Arts and Sciences",
   "bio": "Hey! I'm Thomas, an undergrad from Philly working here at PennLabs on some freaky internal tools and whatnot. I'm a huge frontend TypeScript fan, and when I'm not programming I'm making digital art or awful game prototypes.",
   "hometown": "Philadelphia",
-  "team": "Platform",
-  "roles": ["Frontend"],
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["Frontend"]
+    }
+  ],
   "photo": "https://i.imgur.com/jVkGDrO.jpg",
   "linkedin": "https://www.linkedin.com/in/thomas-shaw-54468b222/",
   "website": null,

--- a/src/json/alumni/vardnan.json
+++ b/src/json/alumni/vardnan.json
@@ -5,9 +5,11 @@
     "school": "Engineering, Weitzman, Wharton",
     "bio": "Interdisciplinary product design student. Spending most of my time questioning if DIG or Sweetgreens is better",
     "hometown": "Oslo, Norway",
-    "team": "Penn Clubs",
-    "roles": [
-        "Designer"
+    "teamRoles": [
+      {
+        "team": "Penn Clubs",
+        "roles": ["Designer"]
+      }
     ],
     "photo": "https://i.imgur.com/nY8UMlv.jpg",
     "linkedin": "https://www.linkedin.com/in/vardnan/",
@@ -17,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2024,
     "job": null
-}
+  }
+  

--- a/src/json/alumni/varunr99.json
+++ b/src/json/alumni/varunr99.json
@@ -5,8 +5,12 @@
   "pennkey": "varunr99",
   "bio": "Varun is a sophomore on the Android team studying Computer Science and Finance. He's primarily interested in computer vision, machine learning, and fintech. Outside of Labs, he enjoys playing basketball, listening to hip-hop music, and playing with his dog, Sid.",
   "hometown": "Santa Rosa, California",
-  "team": "Penn Mobile",
-  "roles": ["Android Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/vhx3Rqa.jpg",
   "linkedin": "https://linkedin.com/in/varunramakrishnan/",
   "website": null,

--- a/src/json/alumni/vfu.json
+++ b/src/json/alumni/vfu.json
@@ -5,8 +5,12 @@
   "pennkey": "vfu",
   "bio": "I'm a UI/UX designer and bizdev who dabbles in frontend. I'm focused on creating integrative experiences in tech, life sciences, and healthcare. Always eating: talk to me about food.",
   "hometown": "Germantown, MD",
-  "team": "Penn Basics",
-  "roles": ["Business Developer", "Designer", "Director Emeritus"],
+  "teamRoles": [
+    {
+      "team": "Penn Basics",
+      "roles": ["Business Developer", "Designer", "Director Emeritus"]
+    }
+  ],
   "photo": "https://i.imgur.com/44AB66h.jpg",
   "linkedin": "https://www.linkedin.com/in/valenciafu/",
   "website": "https://www.valenciafu.me/",

--- a/src/json/alumni/vincetiu.json
+++ b/src/json/alumni/vincetiu.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hey, my name's Vince and I'm a DevOps engineer studying Computer Science! Outside of coding, I love playing basketball, eating ice cream and watching anime. I also love meeting new people and going to hackathons, so feel free to reach out!",
   "hometown": "Manila, Philippines",
-  "team": "Platform",
-  "roles": [
-      "DevOps"
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
   ],
   "photo": "https://i.imgur.com/1Ct4Yu7.jpg",
   "linkedin": "https://www.linkedin.com/in/vincetiu8/",

--- a/src/json/alumni/visheshp.json
+++ b/src/json/alumni/visheshp.json
@@ -1,20 +1,22 @@
 {
-    "name": "Vishesh Patel",
-    "pennkey": "visheshp",
-    "major": "Chemistry and Computer Science",
-    "school": "VIPER: Engineering and CAS",
-    "bio": "Yo! I'm a freshman studying Chemistry and CIS. I'm passionate about using technology to solve problems, specifically in the field of energy and sustainibility.  In my free time, I love playing basketball and tennis, as well as watching sports. ",
-    "hometown": "Glen Mills, PA",
-    "team": "Penn Mobile",
-    "roles": [
-        "Android Mobile Engineer"
-    ],
-    "photo": "https://i.imgur.com/TQ4Ht0g.jpg",
-    "linkedin": "https://www.linkedin.com/in/vishesh-patel-9400a512b",
-    "website": "",
-    "github": "",
-    "semester_joined": "2020C",
-    "alumnus": false,
-    "graduation_year": 2024,
-    "job": null
+  "name": "Vishesh Patel",
+  "pennkey": "visheshp",
+  "major": "Chemistry and Computer Science",
+  "school": "VIPER: Engineering and CAS",
+  "bio": "Yo! I'm a freshman studying Chemistry and CIS. I'm passionate about using technology to solve problems, specifically in the field of energy and sustainibility.  In my free time, I love playing basketball and tennis, as well as watching sports. ",
+  "hometown": "Glen Mills, PA",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/TQ4Ht0g.jpg",
+  "linkedin": "https://www.linkedin.com/in/vishesh-patel-9400a512b",
+  "website": "",
+  "github": "",
+  "semester_joined": "2020C",
+  "alumnus": false,
+  "graduation_year": 2024,
+  "job": null
 }

--- a/src/json/alumni/wgoeller.json
+++ b/src/json/alumni/wgoeller.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hi I'm Will and I'm a Senior studying Computer Engineering and also submatriculating into Computer Science. Outside of classes, I'm a Head TA for CIS120 and a Production Engineer for Jane Street. For fun, I love tinkering, cooking, and downhill skiing!",
   "hometown": "Los Angeles",
-  "team": "Platform",
-  "roles": [
-    "DevOps"
+  "teamRoles": [
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
   ],
   "photo": "https://i.imgur.com/mc5UWeC.jpg",
   "linkedin": "https://www.linkedin.com/in/wgoeller/",

--- a/src/json/alumni/wjhliang.json
+++ b/src/json/alumni/wjhliang.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "CIS major interested in cars. Enjoys singing out-of-tune with his ukulele.",
   "hometown": "Pleasanton, CA",
-  "team": "Office Hours Queue",
-  "roles": ["Designer"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Designer"]
+    }
+  ],
   "photo": "https://i.imgur.com/HSsH8Op.jpg",
   "linkedin": "https://www.linkedin.com/in/willjhliang/",
   "website": "https://www.seas.upenn.edu/~wjhliang/",

--- a/src/json/alumni/yucheny.json
+++ b/src/json/alumni/yucheny.json
@@ -5,9 +5,11 @@
   "school": "Engineering",
   "bio": "Hello World! My name is Tessa and I'm a sophomore studying computer science. In my free time, I love boxing, singing (badly), and traveling. ",
   "hometown": "Irvine, CA",
-  "team": "Penn Courses",
-  "roles": [
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/V4RclNb.png",
   "linkedin": "",

--- a/src/json/alumni/yuewei.json
+++ b/src/json/alumni/yuewei.json
@@ -5,9 +5,11 @@
   "pennkey": "yuewei",
   "bio": "Hi I'm a sophomore studying CIS and I work on PennMobile as a iOS developer. CIS160 is my favorite :) In my free time, I enjoy watching soccer and cooking.",
   "hometown": "Shanghai, China",
-  "team": "Penn Mobile",
-  "roles": [
-    "iOS Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/68MUnzp.png",
   "linkedin": "https://www.linkedin.com/in/yuewei-yuan-659460176/",

--- a/src/json/alumni/yufeix.json
+++ b/src/json/alumni/yufeix.json
@@ -5,8 +5,12 @@
   "school": "Engineering,Wharton",
   "bio": "I'm a junior studying Computer Science and Finance. In free time, I like to explore new restaurants with friends. My favorite restaurant at Phily is Rangoon.",
   "hometown": "Shenzhen, China",
-  "team": "Penn Clubs",
-  "roles": ["Back-End Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/sQC78zH.jpg",
   "linkedin": "https://www.linkedin.com/in/xiayufeilucy/",
   "website": "xiayufeilucy.me",

--- a/src/json/alumni/yxeng.json
+++ b/src/json/alumni/yxeng.json
@@ -5,8 +5,12 @@
   "pennkey": "yxeng",
   "bio": "I'm a front-end engineer for Penn Course Search!",
   "hometown": "Malaysia",
-  "team": "Office Hours Queue",
-  "roles": ["Team Lead", "Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Team Lead", "Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/kVcnwdf.jpg",
   "linkedin": null,
   "website": null,

--- a/src/json/members/_template.json
+++ b/src/json/members/_template.json
@@ -5,8 +5,12 @@
   "school": "",
   "bio": "",
   "hometown": "",
-  "team": "",
-  "roles": [],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": []
+    }
+  ],
   "photo": "https://i.imgur.com/QLVYZ5H.png",
   "linkedin": "",
   "website": "",

--- a/src/json/members/aagamd.json
+++ b/src/json/members/aagamd.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi! I'm Aagam. I'm studying Computer Engineering, with an interest in pursuing robotics. In my free time, I enjoy watching movies and running.",
   "hometown": "Columbus, Ohio",
-  "team": "Penn Courses",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/Sle1FFU.jpeg",
   "linkedin": "https://www.linkedin.com/in/aagam-dalal",
   "website": "https://aadalal.github.io/",

--- a/src/json/members/advitr.json
+++ b/src/json/members/advitr.json
@@ -5,9 +5,11 @@
     "school": "SEAS, College",
     "bio": "Hey, I'm Advit, a freshman in VIPER studying Computer Science and Physics.",
     "hometown": "Mumbai, India",
-    "team": "Penn Courses",
-    "roles": [
-        "Backend Engineer" 
+    "teamRoles": [
+      {
+        "team": "Penn Courses",
+        "roles": ["Backend Engineer"]
+      }
     ],
     "photo": "https://i.imgur.com/Fts4rJe.jpeg",
     "linkedin": "https://www.linkedin.com/in/advit-ranawade-79153b243/",
@@ -16,4 +18,5 @@
     "alumnus": false,
     "graduation_year": 2027,
     "job": null
-}
+  }
+  

--- a/src/json/members/alexb.json
+++ b/src/json/members/alexb.json
@@ -3,11 +3,13 @@
     "pennkey": "abudko",
     "major": "Computer Science",
     "school": "Engineering",
-    "bio": "Hey, I'm Alex and I love coding. In my free time, I also love playing basketball, lifting, and attempting novel and crazy activites.",
+    "bio": "Hey, I'm Alex and I love coding. In my free time, I also love playing basketball, lifting, and attempting novel and crazy activities.",
     "hometown": "Melbourne, FL",
-    "team": "Penn Courses",
-    "roles": [
-        "Backend Engineer"
+    "teamRoles": [
+      {
+        "team": "Penn Courses",
+        "roles": ["Backend Engineer"]
+      }
     ],
     "photo": "https://i.imgur.com/j1qoSMK.jpg",
     "linkedin": "https://www.linkedin.com/in/alexander-budko-41baa7252/",
@@ -16,4 +18,5 @@
     "alumnus": false,
     "graduation_year": 2026,
     "job": null
-}
+  }
+  

--- a/src/json/members/aliu.json
+++ b/src/json/members/aliu.json
@@ -5,8 +5,12 @@
   "school": "College of Arts and Sciences",
   "bio": "Major, undecided. Career, undecided. Life Purpose? Undecided.",
   "hometown": "Portland, Oregon",
-  "team": "Penn Courses",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/jKnoFd7.jpg",
   "linkedin": "https://www.linkedin.com/in/amy-liu-94919b216/",
   "website": "",

--- a/src/json/members/antli.json
+++ b/src/json/members/antli.json
@@ -1,18 +1,22 @@
 {
-    "name": "Anthony Li",
-    "pennkey": "antli",
-    "major": "Computer Science + Finance",
-    "school": "Engineering & Wharton",
-    "bio": "<span style='font-family: \"Comic Sans MS\", casual'>&lt;script&gt;alert(\"<span id='anli-content' style='font-family: monospace'></span>\");&lt;/script&gt;</span><script>let r; r = () => { let t = \"\"; for (let i = 0; i < 10; i++) { t += \"0123456789abcdef\".split(\"\")[Math.floor(Math.random()*16)]; } let e = document.getElementById(\"anli-content\"); if (e) e.innerText = t; window.requestAnimationFrame(r); }; window.requestAnimationFrame(r);</script>",
-    "hometown": "Ridgewood, NJ",
-    "team": "Penn Mobile",
-    "roles": ["iOS Mobile Engineer", "Team Lead"],
-    "photo": "https://avatars.githubusercontent.com/u/7005789?v=4",
-    "linkedin": "https://www.linkedin.com/in/anlidev",
-    "github": "https://github.com/anli5005",
-    "website": "https://anli.dev",
-    "semester_joined": "2022C",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Anthony Li",
+  "pennkey": "antli",
+  "major": "Computer Science + Finance",
+  "school": "Engineering & Wharton",
+  "bio": "<span style='font-family: \"Comic Sans MS\", casual'>&lt;script&gt;alert(\"<span id='anli-content' style='font-family: monospace'></span>\");&lt;/script&gt;</span><script>let r; r = () => { let t = \"\"; for (let i = 0; i < 10; i++) { t += \"0123456789abcdef\".split(\"\")[Math.floor(Math.random()*16)]; } let e = document.getElementById(\"anli-content\"); if (e) e.innerText = t; window.requestAnimationFrame(r); }; window.requestAnimationFrame(r);</script>",
+  "hometown": "Ridgewood, NJ",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer", "Team Lead"]
+    }
+  ],
+  "photo": "https://avatars.githubusercontent.com/u/7005789?v=4",
+  "linkedin": "https://www.linkedin.com/in/anlidev",
+  "github": "https://github.com/anli5005",
+  "website": "https://anli.dev",
+  "semester_joined": "2022C",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/ashzhang.json
+++ b/src/json/members/ashzhang.json
@@ -5,8 +5,12 @@
   "school": "Engineering, Wharton",
   "bio": "Sophomore in M&T studying computer science and finance who enjoys grabbing food with friends, violin/music, and traveling!",
   "hometown": "Paoli, PA",
-  "team": "Penn Mobile",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/eYv9bAg.jpg",
   "linkedin": "https://www.linkedin.com/in/ashley-zhang-b66701209/",
   "website": "",

--- a/src/json/members/asyan.json
+++ b/src/json/members/asyan.json
@@ -1,18 +1,22 @@
 {
-    "name": "Ashley Yan",
-    "pennkey": "asyan",
-    "major": "Computer Science",
-    "school": "Engineering",
-    "bio": "CIS major from Chicago-ish who loves afternoon tea and traveling",
-    "hometown": "Long Grove, IL",
-    "team": "Penn Courses",
-    "roles": ["Backend Engineer"],
-    "photo": "https://i.imgur.com/ztkqo46.jpeg",
-    "linkedin": "https://www.linkedin.com/in/ashley-yan-61b32b210/",
-    "website": "",
-    "github": "https://github.com/ashleymyan",
-    "semester_joined": "2024A",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Ashley Yan",
+  "pennkey": "asyan",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "bio": "CIS major from Chicago-ish who loves afternoon tea and traveling",
+  "hometown": "Long Grove, IL",
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/ztkqo46.jpeg",
+  "linkedin": "https://www.linkedin.com/in/ashley-yan-61b32b210/",
+  "website": "",
+  "github": "https://github.com/ashleymyan",
+  "semester_joined": "2024A",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/aviupadhyayula.json
+++ b/src/json/members/aviupadhyayula.json
@@ -1,18 +1,21 @@
 {
-    "name": "Avi Upadhyayula",
-    "major": "Computer Science",
-    "school": "Engineering",
-    "pennkey": "aviu",
-    "bio": "Issues lead 😔",
-    "hometown": "San Jose, CA",
-    "team": "Penn Clubs",
-    "roles": ["Backend Engineer"],
-    "photo": "https://i.imgur.com/nAR1gcv.jpeg?1",
-    "linkedin": "https://www.linkedin.com/in/aupadhy/",
-    "github": "https://github.com/aviupadhyayula",
-    "semester_joined": "2022C",
-    "alumnus": false,
-    "graduation_year": 2025,
-    "job": null
-  }
-  
+  "name": "Avi Upadhyayula",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "pennkey": "aviu",
+  "bio": "Issues lead 😔",
+  "hometown": "San Jose, CA",
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Backend Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/nAR1gcv.jpeg?1",
+  "linkedin": "https://www.linkedin.com/in/aupadhy/",
+  "github": "https://github.com/aviupadhyayula",
+  "semester_joined": "2022C",
+  "alumnus": false,
+  "graduation_year": 2025,
+  "job": null
+}

--- a/src/json/members/bachtran.json
+++ b/src/json/members/bachtran.json
@@ -1,18 +1,22 @@
 {
-    "name": "Bach Tran",
-    "pennkey": "bachtran",
-    "major": "Computer Science",
-    "school": "Engineering",
-    "bio": "Hi! I'm Bach, a freshman studying Computer Science and a backend engineer for OHQ. I enjoys cats, coding, photography and chilling to music ✨!",
-    "hometown": "Hanoi, Vietnam",
-    "team": "Office Hours Queue",
-    "roles": ["Backend Engineer", "Team Lead"],
-    "photo": "https://i.imgur.com/Uy92N9A.jpg",
-    "linkedin": "https://www.linkedin.com/in/giabachtran/",
-    "website": "https://bach-tran.web.app",
-    "github": "https://github.com/trangiabach",
-    "semester_joined": "2022C",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Bach Tran",
+  "pennkey": "bachtran",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "bio": "Hi! I'm Bach, a freshman studying Computer Science and a backend engineer for OHQ. I enjoy cats, coding, photography and chilling to music ✨!",
+  "hometown": "Hanoi, Vietnam",
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer", "Team Lead"]
+    }
+  ],
+  "photo": "https://i.imgur.com/Uy92N9A.jpg",
+  "linkedin": "https://www.linkedin.com/in/giabachtran/",
+  "website": "https://bach-tran.web.app",
+  "github": "https://github.com/trangiabach",
+  "semester_joined": "2022C",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/benxu.json
+++ b/src/json/members/benxu.json
@@ -1,18 +1,22 @@
 {
-    "name": "Benjamin Xu",
-    "pennkey": "benxu",
-    "major": "CIS",
-    "school": "SEAS",
-    "bio": "Hi I'm Benjamin, a sophomore studying CIS in SEAS and working on Backend for OHQ.",
-    "hometown": "Saratoga, California",
-    "team": "Office Hours Queue",
-    "roles": ["Backend Engineer"],
-    "photo": "https://i.imgur.com/ISMe305.jpg",
-    "linkedin": "www.linkedin.com/in/benjamin-xu-933248185",
-    "website": "",
-    "github": "https://github.com/benjmnxu",
-    "semester_joined": "2023C",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": "Backend"
-  }
+  "name": "Benjamin Xu",
+  "pennkey": "benxu",
+  "major": "CIS",
+  "school": "SEAS",
+  "bio": "Hi I'm Benjamin, a sophomore studying CIS in SEAS and working on Backend for OHQ.",
+  "hometown": "Saratoga, California",
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/ISMe305.jpg",
+  "linkedin": "www.linkedin.com/in/benjamin-xu-933248185",
+  "website": "",
+  "github": "https://github.com/benjmnxu",
+  "semester_joined": "2023C",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": "Backend"
+}

--- a/src/json/members/bpyhsieh.json
+++ b/src/json/members/bpyhsieh.json
@@ -5,8 +5,12 @@
   "school": "College of Arts and Sciences",
   "bio": "Hello! I'm currently an aspiring programmer who hopes to expand my skillset in app design and gamedev.",
   "hometown": "Taipei, Taiwan",
-  "team": "Penn Mobile",
-  "roles": ["Android Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/wDs56DN.jpg",
   "linkedin": "https://www.linkedin.com/in/baron-ping-yeh-hsieh-976376290/",
   "website": "",

--- a/src/json/members/caiv.json
+++ b/src/json/members/caiv.json
@@ -5,10 +5,11 @@
     "school": "Engineering",
     "bio": "CIS major who really enjoys eating. Can usually be found binging youtube.",
     "hometown": "Hockessin, DE",
-    "team": "Penn Mobile",
-    "roles": [
-        "Backend Engineer",
-        "Team Lead"
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Backend Engineer", "Team Lead"]
+      }
     ],
     "photo": "https://i.imgur.com/C2woD6V.jpeg",
     "linkedin": "https://www.linkedin.com/in/caiv",
@@ -18,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2025,
     "job": null
-}
+  }
+  

--- a/src/json/members/ccheng12.json
+++ b/src/json/members/ccheng12.json
@@ -5,8 +5,12 @@
     "school": "College of Arts & Sciences",
     "bio": "Hi, I'm Chelsea! I'm a Designer for Penn Mobile studying CogSci. In my free time, I like reading, playing guitar and drawing :)",
     "hometown": "Chicago, Illinois",
-    "team": "Penn Mobile",
-    "roles": ["Designer"],
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Designer"]
+      }
+    ],
     "photo": "https://i.imgur.com/HLVUv4I.jpg",
     "linkedin": "https://www.linkedin.com/in/chelsea-cheng-12/",
     "website": "https://chelseacheng.com",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2024,
     "job": null
-}
+  }
+  

--- a/src/json/members/ccheng25.json
+++ b/src/json/members/ccheng25.json
@@ -5,8 +5,12 @@
     "school": "CAS & Wharton",
     "bio": "loves all things art & design <3.",
     "hometown": "Princeton, New Jersey",
-    "team": "Penn Mobile",
-    "roles": ["Designer"],
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Designer"]
+      }
+    ],
     "photo": "https://i.imgur.com/h4Cxqlg.jpg",
     "linkedin": "https://www.linkedin.com/in/christinecheng/",
     "website": "",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2025,
     "job": null
-}
+  }
+  

--- a/src/json/members/charisg.json
+++ b/src/json/members/charisg.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "CIS major with a love for watching sunsets, taking personality tests, and chai lattes.",
   "hometown": "Princeton, NJ",
-  "team": "Office Hours Queue",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/X3WCRH3.png",
   "linkedin": "https://www.linkedin.com/in/charisgao/",
   "website": "",

--- a/src/json/members/chenmel.json
+++ b/src/json/members/chenmel.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Photography, eating, coffee, music, and forever trying to get into crocheting",
   "hometown": "Holmdel, NJ",
-  "team": "Penn Clubs",
-  "roles": ["Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Business Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/S0APygI.jpeg",
   "linkedin": "https://www.linkedin.com/in/melaniechen864/",
   "website": "",

--- a/src/json/members/choiyoon.json
+++ b/src/json/members/choiyoon.json
@@ -1,18 +1,22 @@
 {
-    "name": "Yoonjung Choi",
-    "pennkey": "choiyoon",
-    "major": "Undecided",
-    "school": "SAS",
-    "bio": "Hi, this is Yoonjung. I'm a BizDev for Penn Clubs.",
-    "hometown": "Hong Kong",
-    "team": "Penn Clubs",
-    "roles": ["Business Developer"],
-    "photo": "https://i.imgur.com/grmQbtV.jpeg",
-    "linkedin": "https://www.linkedin.com/in/yoonjungchoi05/",
-    "website": "",
-    "github": "https://github.com/yoonjung27",
-    "semester_joined": "2023C",
-    "alumnus": false,
-    "graduation_year": 2027,
-    "job": null
-  }
+  "name": "Yoonjung Choi",
+  "pennkey": "choiyoon",
+  "major": "Undecided",
+  "school": "SAS",
+  "bio": "Hi, this is Yoonjung. I'm a BizDev for Penn Clubs.",
+  "hometown": "Hong Kong",
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Business Developer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/grmQbtV.jpeg",
+  "linkedin": "https://www.linkedin.com/in/yoonjungchoi05/",
+  "website": "",
+  "github": "https://github.com/yoonjung27",
+  "semester_joined": "2023C",
+  "alumnus": false,
+  "graduation_year": 2027,
+  "job": null
+}

--- a/src/json/members/chuu.json
+++ b/src/json/members/chuu.json
@@ -1,18 +1,22 @@
 {
-    "name": "Christina Qiu",
-    "pennkey": "chuu",
-    "major": "Digital Media Design",
-    "school": "Engineering",
-    "bio": "Hi! My name is Christina Qiu and I'm a Digital Media Design major (Computer Graphics). I love drawing, listening to music, and watching anime.",
-    "hometown": "Montclair, NJ",
-    "team": "Penn Mobile",
-    "roles": ["iOS Mobile Engineer"],
-    "photo": "https://i.imgur.com/DIrp3lH.jpeg",
-    "linkedin": "https://www.linkedin.com/in/christina-qiu-6094301b6/",
-    "website": "",
-    "github": "https://github.com/christinaqiu3",
-    "semester_joined": "2023C",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Christina Qiu",
+  "pennkey": "chuu",
+  "major": "Digital Media Design",
+  "school": "Engineering",
+  "bio": "Hi! My name is Christina Qiu and I'm a Digital Media Design major (Computer Graphics). I love drawing, listening to music, and watching anime.",
+  "hometown": "Montclair, NJ",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/DIrp3lH.jpeg",
+  "linkedin": "https://www.linkedin.com/in/christina-qiu-6094301b6/",
+  "website": "",
+  "github": "https://github.com/christinaqiu3",
+  "semester_joined": "2023C",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/danxue.json
+++ b/src/json/members/danxue.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "NETS major with an interest in computing and public policy. Often found breaking things (by accident, mostly) and building things.",
   "hometown": "Princeton, NJ",
-  "team": "Office Hours Queue",
-  "roles": ["Frontend Engineer", "Team Lead"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Frontend Engineer", "Team Lead"]
+    }
+  ],
   "photo": "https://i.imgur.com/VlRqhvH.jpg",
   "linkedin": "https://www.linkedin.com/in/daniel-l-xue/",
   "website": "",

--- a/src/json/members/dyzhao.json
+++ b/src/json/members/dyzhao.json
@@ -5,8 +5,12 @@
     "school": "Engineering",
     "bio": "Hi! I'm a freshman in MEAM from Alabama. In my free time I am either watching football or drinking sweet tea. Roll tide!",
     "hometown": "Hoover, AL",
-    "team": "Penn Courses",
-    "roles": ["Backend Engineer"],
+    "teamRoles": [
+      {
+        "team": "Penn Courses",
+        "roles": ["Backend Engineer"]
+      }
+    ],
     "photo": "https://i.imgur.com/tf5Wqqh.png",
     "linkedin": "https://www.linkedin.com/in/daniel-zhao-98625a28b/",
     "website": "",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2027,
     "job": null
-}
+  }
+  

--- a/src/json/members/eecho.json
+++ b/src/json/members/eecho.json
@@ -5,8 +5,12 @@
   "school": "College of Arts and Sciences",
   "bio": "",
   "hometown": "San Diego, CA",
-  "team": "Penn Courses",
-  "roles": ["Designer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Designer"]
+    }
+  ],
   "photo": "https://i.imgur.com/QLVYZ5H.png",
   "linkedin": "https://linkedin.com/in/eecho-yuan-01a23a28b",
   "website": "",

--- a/src/json/members/esinx.json
+++ b/src/json/members/esinx.json
@@ -5,8 +5,20 @@
   "school": "Engineering",
   "bio": "Stay TypeSafe™, everyone",
   "hometown": "Seoul, South Korea",
-  "team": ["Penn Courses", "Penn Clubs", "Platform"],
-  "roles": ["Frontend Engineer", "Team Lead", "DevOps"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Team Lead", "Frontend Engineer"]
+    },
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    },
+    {
+      "team": "Platform",
+      "roles": ["DevOps"]
+    }
+  ],
   "photo": "https://avatars3.githubusercontent.com/u/62971511?s=460&u=c9f59555a34989c2c527df86478fadbf3edafaae&v=4",
   "linkedin": "https://www.linkedin.com/in/esinx",
   "website": "https://esinx.net",

--- a/src/json/members/evanping.json
+++ b/src/json/members/evanping.json
@@ -5,8 +5,12 @@
   "school": "SEAS",
   "bio": "CIS major, Pokemon lover, and bench spammer",
   "hometown": "Bellevue, WA",
-  "team": "Penn Mobile",
-  "roles": ["Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Business Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/OBLCVD8.jpg",
   "linkedin": "https://www.linkedin.com/in/evanping/",
   "website": "",

--- a/src/json/members/exwang.json
+++ b/src/json/members/exwang.json
@@ -5,8 +5,12 @@
   "school": "SAS",
   "bio": "Cog Sci and CIS major interested in trying new restaurants!",
   "hometown": "Naperville, IL",
-  "team": "Office Hours Queue",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/I0IbvVo.png",
   "linkedin": "www.linkedin.com/in/ethanwang04",
   "website": "",

--- a/src/json/members/gbotros.json
+++ b/src/json/members/gbotros.json
@@ -3,10 +3,14 @@
   "pennkey": "gbotros",
   "major": "Computer Science",
   "school": "Engineering",
-  "bio": "Hi! I'm George, and I am a sophomore majoring in Computer Science. In my freetime, I love cooking (even though I'm not very good at it) and hiking!",
+  "bio": "Hi! I'm George, and I am a sophomore majoring in Computer Science. In my free time, I love cooking (even though I'm not very good at it) and hiking!",
   "hometown": "Mount Laurel, New Jersey",
-  "team": "Penn Mobile",
-  "roles": ["iOS Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/Hs4lAZU.jpg",
   "linkedin": "https://www.linkedin.com/in/georgebotros02/",
   "website": "",

--- a/src/json/members/grohan.json
+++ b/src/json/members/grohan.json
@@ -5,11 +5,11 @@
   "pennkey": "grohan",
   "bio": "Junior in NETS. Likes RuneScape, snake_case, Vim, Emacs, types, distributed systems, strawberry milk, green grass. Dislikes frontend, unit tests, queues, rice",
   "hometown": "Bangalore, India",
-  "team": "Penn Clubs",
-  "roles": [
-    "Director Emeritus",
-    "Backend Engineer",
-    "Team Lead"
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Director Emeritus", "Backend Engineer", "Team Lead"]
+    }
   ],
   "photo": "https://avatars.githubusercontent.com/u/13982777?v=2",
   "linkedin": "https://www.linkedin.com/in/rohan-gupta2/",

--- a/src/json/members/helenazh.json
+++ b/src/json/members/helenazh.json
@@ -1,18 +1,22 @@
 {
-    "name": "Helena Zhou",
-    "pennkey": "helenazh",
-    "major": "Computer Science",
-    "school": "Engineering",
-    "bio": "Hi! I like to cycle, play pickleball, and try new foods.",
-    "hometown": "Irvine, CA",
-    "team": "Penn Courses",
-    "roles": ["Frontend Engineer"],
-    "photo": "https://i.imgur.com/WC8KaYY.jpeg",
-    "linkedin": "https://linkedin.com/in/helena-zhou/",
-    "website": "",
-    "github": "https://github.com/zhouhelena",
-    "semester_joined": "2024A",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Helena Zhou",
+  "pennkey": "helenazh",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "bio": "Hi! I like to cycle, play pickleball, and try new foods.",
+  "hometown": "Irvine, CA",
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/WC8KaYY.jpeg",
+  "linkedin": "https://linkedin.com/in/helena-zhou/",
+  "website": "",
+  "github": "https://github.com/zhouhelena",
+  "semester_joined": "2024A",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/jackyf.json
+++ b/src/json/members/jackyf.json
@@ -1,18 +1,22 @@
 {
-    "name": "Jacky Fang",
-    "pennkey": "jackyf",
-    "major": "Computer Science",
-    "school": "Engineering",
-    "bio": "lover of mcdonald's fries",
-    "hometown": "Brooklyn, NY",
-    "team": "Penn Mobile",
-    "roles": ["iOS Mobile Engineer"],
-    "photo": "https://i.imgur.com/dZ6gM3E.jpg",
-    "linkedin": "https://www.linkedin.com/in/jackyfang0/",
-    "website": "",
-    "github": "https://github.com/innocentoak",
-    "semester_joined": "2024A",
-    "alumnus": false,
-    "graduation_year": 2025,
-    "job": null
-  }
+  "name": "Jacky Fang",
+  "pennkey": "jackyf",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "bio": "lover of mcdonald's fries",
+  "hometown": "Brooklyn, NY",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/dZ6gM3E.jpg",
+  "linkedin": "https://www.linkedin.com/in/jackyfang0/",
+  "website": "",
+  "github": "https://github.com/innocentoak",
+  "semester_joined": "2024A",
+  "alumnus": false,
+  "graduation_year": 2025,
+  "job": null
+}

--- a/src/json/members/jennyzli.json
+++ b/src/json/members/jennyzli.json
@@ -5,8 +5,12 @@
   "school": "College of Arts and Sciences",
   "bio": "Hi! I'm a freshman in the College considering Cognitive Science and Design. I love painting, reading, and music.",
   "hometown": "Rochester, NY",
-  "team": "Penn Mobile",
-  "roles": ["Designer", "Team Lead"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer", "Team Lead"]
+    }
+  ],
   "photo": "https://i.imgur.com/ShB1x2E.jpg",
   "linkedin": "www.linkedin.com/in/jenny-li-4a7880202",
   "website": "https://byjennny.wixsite.com/website-1",

--- a/src/json/members/jesnipes.json
+++ b/src/json/members/jesnipes.json
@@ -1,19 +1,22 @@
 {
- "name": "Julius Snipes",
- "pennkey": "jesnipes",
- "major": "Computer Science",
- "school": "Engineering",
- "bio": "I'm an Android developer working on Penn Mobile studying CIS. When I'm not coding, I'm listening to music, watching anime, playing video games or playing basketball.",
- "hometown": "Dover, DE",
- "team": "Penn Mobile",
- "roles": ["Android Mobile Engineer", "Team Lead"],
- "photo": "https://i.imgur.com/63CaFxr.jpg",
- "linkedin": "https://www.linkedin.com/in/julius-snipes/",
- "website": "",
- "github": "https://github.com/JSnipes29",
- "semester_joined": "2021C",
- "alumnus": false,
- "graduation_year": 2024,
- "job": null
+  "name": "Julius Snipes",
+  "pennkey": "jesnipes",
+  "major": "Computer Science",
+  "school": "Engineering",
+  "bio": "I'm an Android developer working on Penn Mobile studying CIS. When I'm not coding, I'm listening to music, watching anime, playing video games or playing basketball.",
+  "hometown": "Dover, DE",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer", "Team Lead"]
+    }
+  ],
+  "photo": "https://i.imgur.com/63CaFxr.jpg",
+  "linkedin": "https://www.linkedin.com/in/julius-snipes/",
+  "website": "",
+  "github": "https://github.com/JSnipes29",
+  "semester_joined": "2021C",
+  "alumnus": false,
+  "graduation_year": 2024,
+  "job": null
 }
-

--- a/src/json/members/jessez.json
+++ b/src/json/members/jessez.json
@@ -5,8 +5,12 @@
     "school": "Engineering",
     "bio": "Hi, I'm Jesse! \n I'm a CIS major in Engineering and a backend dev for Penn Mobile. When I'm not up late coding, you can catch me cooking up something tasty, gardening at KCECH, or clowning around with my friends.",
     "hometown": "Ellicott City, Maryland",
-    "team": "Penn Mobile",
-    "roles": ["Backend Engineer"],
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Backend Engineer"]
+      }
+    ],
     "photo": "https://i.imgur.com/fJfugrt.png",
     "linkedin": "https://www.linkedin.com/in/jesse-zong-607199227/",
     "website": "",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2027,
     "job": null
-}
+  }
+  

--- a/src/json/members/jhawkman.json
+++ b/src/json/members/jhawkman.json
@@ -1,18 +1,22 @@
 {
-    "name": "Jordan Hochman",
-    "pennkey": "jhawkman",
-    "major": "Computer Science + Mathematics",
-    "school": "Engineering",
-    "bio": "Hi! I'm Jordan, a junior at UPenn, and I'm pursuing a BSE in Computer Science, a second major in Mathematics, and a minor in Statistics! I'm very interested in machine learning, and in my free time I love playing pickleball, making educational YouTube videos, and playing the piano!",
-    "hometown": "Naples, Florida",
-    "team": "Penn Mobile",
-    "roles": ["iOS Mobile Engineer", "Team Lead"],
-    "photo": "https://i.imgur.com/31gi0lQ.png",
-    "linkedin": "https://www.linkedin.com/in/jhochman24/",
-    "website": "https://jordanh.xyz/",
-    "github": "https://github.com/jhawk0224",
-    "semester_joined": "2022C",
-    "alumnus": false,
-    "graduation_year": 2025,
-    "job": null
-  }
+  "name": "Jordan Hochman",
+  "pennkey": "jhawkman",
+  "major": "Computer Science + Mathematics",
+  "school": "Engineering",
+  "bio": "Hi! I'm Jordan, a junior at UPenn, and I'm pursuing a BSE in Computer Science, a second major in Mathematics, and a minor in Statistics! I'm very interested in machine learning, and in my free time I love playing pickleball, making educational YouTube videos, and playing the piano!",
+  "hometown": "Naples, Florida",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer", "Team Lead"]
+    }
+  ],
+  "photo": "https://i.imgur.com/31gi0lQ.png",
+  "linkedin": "https://www.linkedin.com/in/jhochman24/",
+  "website": "https://jordanh.xyz/",
+  "github": "https://github.com/jhawk0224",
+  "semester_joined": "2022C",
+  "alumnus": false,
+  "graduation_year": 2025,
+  "job": null
+}

--- a/src/json/members/joemacd.json
+++ b/src/json/members/joemacd.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi, I'm a software dev interested in mobile development, biometrics research, and more!",
   "hometown": "Golden, CO",
-  "team": "Penn Mobile",
-  "roles": ["Android Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/OU2TGRa.jpg",
   "linkedin": "https://www.linkedin.com/in/joseph-macdougall-316250277/",
   "website": "",

--- a/src/json/members/jonx.json
+++ b/src/json/members/jonx.json
@@ -5,9 +5,11 @@
   "school": "Wharton",
   "bio": "Hi! I'm a sophomore at Penn who enjoys building things big and small! Running frontend on Penn Mobile Portal (even though my job's about to be replaced by AI..) Love to connect! ✌️",
   "hometown": "Lower Merion, PA",
-  "team": "Penn Mobile",
-  "roles": [
-    "Frontend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Frontend Engineer"]
+    }
   ],
   "photo": "https://i.ibb.co/3BZKGJg/profile.png",
   "linkedin": "https://www.linkedin.com/in/jonathanrxu/",

--- a/src/json/members/joyliu.json
+++ b/src/json/members/joyliu.json
@@ -5,8 +5,16 @@
   "school": "Engineering & Wharton",
   "bio": "Hi, I'm Joy! :D \n\n I'm a Software Engineer interested in infrastructure (DevOps, Cloud, systems) and applications (web, UI/UX). Outside Labs, I love TA-ing, drawing, and hacking up new projects!",
   "hometown": "Portland, Oregon",
-  "team": ["Directors", "Platform"],
-  "roles": ["Co-Director", "Team Lead", "DevOps"],
+  "teamRoles": [
+    {
+      "team": "Directors",
+      "roles": ["Co-Director"]
+    },
+    {
+      "team": "Platform",
+      "roles": ["Team Lead", "DevOps"]
+    }
+  ],
   "photo": "https://i.imgur.com/65CoFe0.jpg",
   "linkedin": "https://www.linkedin.com/in/qijia-joy-liu/",
   "website": "https://www.joyliu.dev/",

--- a/src/json/members/judtin.json
+++ b/src/json/members/judtin.json
@@ -5,10 +5,11 @@
   "school": "Engineering",
   "bio": "Hi! I'm a current junior studying CIS. I'm really interested in astronomy, code, movies, and, of course, foooood!",
   "hometown": "Holmdel, NJ",
-  "team": "Penn Mobile",
-  "roles": [
-    "Team Lead",
-    "Backend Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Team Lead", "Backend Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/0Rm6ewe.jpg",
   "linkedin": "https://www.linkedin.com/in/justin-a-zhang/",

--- a/src/json/members/justinsun.json
+++ b/src/json/members/justinsun.json
@@ -1,18 +1,22 @@
 {
-    "name": "Justin Sun",
-    "pennkey": "jsunyt",
-    "major": "Computer Science + Entrepreneurship",
-    "school": "Engineering & Wharton",
-    "bio": "Yo! I'm Justin, full-stack dev interested in the intersection of AI and education. I like photography, gaming, and going to the gym!",
-    "hometown": "Shanghai, China",
-    "team": "Penn Mobile",
-    "roles": ["iOS Mobile Engineer"],
-    "photo": "https://i.imgur.com/8jqcdIu.png",
-    "linkedin": "https://linkedin.com/in/justinsunyt/",
-    "website": "https://justinsun.me",
-    "github": "https://github.com/justinsunyt",
-    "semester_joined": "2023A",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Justin Sun",
+  "pennkey": "jsunyt",
+  "major": "Computer Science + Entrepreneurship",
+  "school": "Engineering & Wharton",
+  "bio": "Yo! I'm Justin, full-stack dev interested in the intersection of AI and education. I like photography, gaming, and going to the gym!",
+  "hometown": "Shanghai, China",
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/8jqcdIu.png",
+  "linkedin": "https://linkedin.com/in/justinsunyt/",
+  "website": "https://justinsun.me",
+  "github": "https://github.com/justinsunyt",
+  "semester_joined": "2023A",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/jw0.json
+++ b/src/json/members/jw0.json
@@ -5,8 +5,12 @@
   "school": "Engineering & Wharton",
   "bio": "Passionate about building tech that generates real value and getting eight hours of sleep.",
   "hometown": "Westport, Connecticut",
-  "team": "Penn Clubs",
-  "roles": ["Frontend Engineer", "Team Lead"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer", "Team Lead"]
+    }
+  ],
   "photo": "https://i.imgur.com/EJmmGhS.jpg",
   "linkedin": "https://www.linkedin.com/in/julianweng/",
   "website": "https://julianweng.com/",

--- a/src/json/members/jzwchen.json
+++ b/src/json/members/jzwchen.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Sophomore in DMD studying computer science graphics and loves spotify group sessions and a sweet treat!",
   "hometown": "Portland, OR",
-  "team": "Penn Mobile",
-  "roles": ["Designer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Designer"]
+    }
+  ],
   "photo": "https://i.imgur.com/K775b06.jpeg",
   "linkedin": "https://www.linkedin.com/in/joyce-chen-75665b226/",
   "website": "https://joycezchen.myportfolio.com/work",

--- a/src/json/members/kboonst.json
+++ b/src/json/members/kboonst.json
@@ -5,11 +5,11 @@
   "school": "Engineering",
   "bio": "Hi there! I'm a Business Developer for Penn Courses studying Materials Science & Engineering. I'm interested in product development, materials applications, and environmental technology. When I'm not in Labs or studying, I like to sing (check out Off The Beat!), bike, and hang out with friends.",
   "hometown": "Chicago, IL",
-  "team": "Penn Courses",
-  "roles": [
-    "Director Emeritus",
-    "Business Developer",
-    "Designer"
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Director Emeritus", "Business Developer", "Designer"]
+    }
   ],
   "photo": "https://i.imgur.com/OoguqPg.jpeg",
   "linkedin": "",

--- a/src/json/members/kunliz.json
+++ b/src/json/members/kunliz.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hello! I'm a CIS major from down under. In my free time I enjoy playing squash, travelling, and eating way too much food.",
   "hometown": "Auckland, New Zealand",
-  "team": "Penn Mobile",
-  "roles": ["iOS Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/3FqZiK3.jpg",
   "linkedin": "http://www.linkedin.com/in/kunlizhang",
   "website": null,

--- a/src/json/members/leerache.json
+++ b/src/json/members/leerache.json
@@ -1,18 +1,22 @@
 {
-    "name": "Rachel Lee",
-    "pennkey": "leerache",
-    "major": "Finance/Management",
-    "school": "Wharton",
-    "bio": "Hi! I'm a sophomore studying finance & management with an intended submat in CIS. I like cafe hopping & talking about my F1 fantasy team.",
-    "hometown": "Novi, MI",
-    "team": "Office Hours Queue",
-    "roles": ["Business Developer"],
-    "photo": "https://i.imgur.com/FFfweIC.jpeg",
-    "linkedin": "https://www.linkedin.com/in/leerache/",
-    "website": "",
-    "github": "https://github.com/rachllee",
-    "semester_joined": "2023C",
-    "alumnus": false,
-    "graduation_year": 2026,
-    "job": null
-  }
+  "name": "Rachel Lee",
+  "pennkey": "leerache",
+  "major": "Finance/Management",
+  "school": "Wharton",
+  "bio": "Hi! I'm a sophomore studying finance & management with an intended submat in CIS. I like cafe hopping & talking about my F1 fantasy team.",
+  "hometown": "Novi, MI",
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Business Developer"]
+    }
+  ],
+  "photo": "https://i.imgur.com/FFfweIC.jpeg",
+  "linkedin": "https://www.linkedin.com/in/leerache/",
+  "website": "",
+  "github": "https://github.com/rachllee",
+  "semester_joined": "2023C",
+  "alumnus": false,
+  "graduation_year": 2026,
+  "job": null
+}

--- a/src/json/members/lianxunw.json
+++ b/src/json/members/lianxunw.json
@@ -5,8 +5,12 @@
     "school": "College",
     "bio": "I'm a junior UX designer at Penn Clubs.",
     "hometown": "Wuhan, China",
-    "team": "Penn Clubs",
-    "roles": ["Designer"],
+    "teamRoles": [
+      {
+        "team": "Penn Clubs",
+        "roles": ["Designer"]
+      }
+    ],
     "photo": "https://media.licdn.com/dms/image/D4D03AQHc25CB2HLVlw/profile-displayphoto-shrink_800_800/0/1680745569202?e=1715817600&v=beta&t=iV1yx9NBsieOv7hxLSYtaovMhoVKxyDbQml0B-Y8iF0",
     "linkedin": "https://www.linkedin.com/in/lianxun-wang/",
     "website": "https://jasminewangux.com/",
@@ -15,5 +19,5 @@
     "alumnus": false,
     "graduation_year": 2025,
     "job": null
-}
+  }
   

--- a/src/json/members/liuchris.json
+++ b/src/json/members/liuchris.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi! I'm a software developer studying CS and linguistics who loves building cool things. I love my dog and the Yankees :)",
   "hometown": "New York, NY",
-  "team": "Directors",
-  "roles": ["Co-Director", "Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Directors",
+      "roles": ["Co-Director", "Backend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/o1mNkTP.jpeg",
   "linkedin": "https://www.linkedin.com/in/christopher-liu-a343511a8/",
   "website": "",

--- a/src/json/members/lukert.json
+++ b/src/json/members/lukert.json
@@ -5,8 +5,12 @@
     "school": "College",
     "bio": "Hi! I'm a freshmen on the Courses team. I like biking and horror movies.",
     "hometown": "Princeton, New Jersey",
-    "team": "Penn Courses",
-    "roles": ["Frontend Engineer"],
+    "teamRoles": [
+      {
+        "team": "Penn Courses",
+        "roles": ["Frontend Engineer"]
+      }
+    ],
     "photo": "https://avatars.githubusercontent.com/u/56455367?v=4",
     "linkedin": "https://www.linkedin.com/in/luke-rt",
     "website": "https://lukert.me",
@@ -15,5 +19,5 @@
     "alumnus": false,
     "graduation_year": 2027,
     "job": null
-}
+  }
   

--- a/src/json/members/meiron.json
+++ b/src/json/members/meiron.json
@@ -5,8 +5,12 @@
     "school": "Engineering",
     "bio": "Hello! I'm a sophomore studying CIS from Maryland. In my free time, I enjoy running, playing video games and thinking about algorithms.",
     "hometown": "North Potomac, MD",
-    "team": "Penn Mobile",
-    "roles": ["Android Mobile Engineer", "Team Lead"],
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Android Mobile Engineer", "Team Lead"]
+      }
+    ],
     "photo": "https://i.imgur.com/9SWyLAQ.jpg",
     "linkedin": "https://www.linkedin.com/in/aaron-mei-513b73a2/",
     "website": "",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2025,
     "job": null
-}
+  }
+  

--- a/src/json/members/melitski.json
+++ b/src/json/members/melitski.json
@@ -5,9 +5,11 @@
   "school": "College",
   "bio": "hawaiian shirt enthusiast",
   "hometown": "Red Hook, NY",
-  "team": "Penn Mobile",
-  "roles": [
-    "iOS Mobile Engineer"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineer"]
+    }
   ],
   "photo": "https://i.imgur.com/lOFooMx.jpeg",
   "linkedin": "",

--- a/src/json/members/msli.json
+++ b/src/json/members/msli.json
@@ -5,8 +5,12 @@
   "school": "CAS",
   "bio": "Hallo! My name is Michael and I like cats even (if they don't like me).",
   "hometown": "Rochester, NY",
-  "team": "Penn Mobile",
-  "roles": ["Business Developer", "Team Lead"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Business Developer", "Team Lead"]
+    }
+  ],
   "photo": "https://i.imgur.com/Gd45igF.jpg",
   "linkedin": "https://www.linkedin.com/in/msli/",
   "website": "",

--- a/src/json/members/nmounier.json
+++ b/src/json/members/nmounier.json
@@ -5,9 +5,11 @@
   "school": "Engineering & Wharton",
   "bio": "Hello there! I'm Nikita, and I'm studying CS at the Engineering school and Finance+Entrepreneurship at Wharton. I love functional programming, jazz, and house music, or any combination of those three.",
   "hometown": "London, United Kingdom",
-  "team": "Penn Mobile",
-  "roles": [
-    "iOS Mobile Engineering"
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["iOS Mobile Engineering"]
+    }
   ],
   "photo": "https://i.imgur.com/pRYlrER.jpg",
   "linkedin": "https://www.linkedin.com/in/nikita-mounier-b80539216/",

--- a/src/json/members/owlester.json
+++ b/src/json/members/owlester.json
@@ -5,8 +5,12 @@
   "school": "SEAS",
   "bio": "Hi!",
   "hometown": "Villanova",
-  "team": "Penn Clubs",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/iyxC0v0.jpeg",
   "linkedin": "https://www.linkedin.com/in/owen-lester-7b16b8289/",
   "website": "",

--- a/src/json/members/rchhaya.json
+++ b/src/json/members/rchhaya.json
@@ -5,8 +5,12 @@
   "pennkey": "rchhaya",
   "bio": "A bioengineering, computer science, and data science student looking to explore mobile development and maybe learn how to debug without System.out.println()",
   "hometown": "Plano, Texas",
-  "team": "Penn Mobile",
-  "roles": ["Team Lead", "Android Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Team Lead", "Android Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/foDwf0O.jpeg",
   "linkedin": "https://www.linkedin.com/in/rohan-chhaya/",
   "website": "https://rohanchhaya.com/",

--- a/src/json/members/rdoman.json
+++ b/src/json/members/rdoman.json
@@ -5,8 +5,12 @@
   "school": "Wharton",
   "bio": "Hi! I'm a sophomore from Atlanta. I love to bike, travel, and bake!",
   "hometown": "Atlanta, GA",
-  "team": "Penn Courses",
-  "roles": ["Business Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Business Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/EPD2YHl.jpeg",
   "linkedin": "https://www.linkedin.com/in/racheldoman/",
   "website": "",

--- a/src/json/members/rmoniz.json
+++ b/src/json/members/rmoniz.json
@@ -5,8 +5,12 @@
     "school": "Engineering",
     "bio": "Always locked in 🔐",
     "hometown": "Glen Ridge, NJ",
-    "team": "Penn Clubs",
-    "roles": ["Backend Engineer", "Team Lead"],
+    "teamRoles": [
+      {
+        "team": "Penn Clubs",
+        "roles": ["Backend Engineer", "Team Lead"]
+      }
+    ],
     "photo": "https://avatars.githubusercontent.com/u/60864468?v=4",
     "linkedin": "https://www.linkedin.com/in/rohan-moniz/",
     "website": "https://www.rohanmoniz.com",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2025,
     "job": null
-}
+  }
+  

--- a/src/json/members/rydersit.json
+++ b/src/json/members/rydersit.json
@@ -5,8 +5,12 @@
     "school": "Engineering",
     "bio": "Hey, I'm Ryder and I'm a Sophomore from Minnesota! In my free time I enjoy playing pickup soccer, cooking beef wellington, and losing my money in poker.",
     "hometown": "Woodbury, MN",
-    "team": "Penn Courses",
-    "roles": ["Frontend Engineer"],
+    "teamRoles": [
+      {
+        "team": "Penn Courses",
+        "roles": ["Frontend Engineer"]
+      }
+    ],
     "photo": "https://i.imgur.com/aM2cvav.png",
     "linkedin": "https://www.linkedin.com/in/ryder-sitcawich/",
     "github": "https://github.com/rydersitcawich",
@@ -14,4 +18,5 @@
     "alumnus": false,
     "graduation_year": 2026,
     "job": null
-}
+  }
+  

--- a/src/json/members/smenta.json
+++ b/src/json/members/smenta.json
@@ -1,18 +1,22 @@
 {
-    "name": "Shiva Menta",
-    "pennkey": "smenta",
-    "major": "Economics",
-    "school": "Wharton",
-    "bio": "Hey! I'm Shiva and I study Economics and Computer Science. In my free time, I love listening to EDM and DJ'ing. Hit me up if you want to rave together.",
-    "hometown": "Burr Ridge, Illinois",
-    "team": "Penn Courses",
-    "roles": ["Backend Engineer", "Team Lead"],
-    "photo": "https://i.imgur.com/Cbh9UsT.jpeg",
-    "linkedin": "https://www.linkedin.com/in/shiva-menta-472750147/",
-    "website": "https://shivamenta.me/",
-    "github": "https://github.com/shiva-menta",
-    "semester_joined": "2023A",
-    "alumnus": false,
-    "graduation_year": 2024,
-    "job": null
-  }
+  "name": "Shiva Menta",
+  "pennkey": "smenta",
+  "major": "Economics",
+  "school": "Wharton",
+  "bio": "Hey! I'm Shiva and I study Economics and Computer Science. In my free time, I love listening to EDM and DJ'ing. Hit me up if you want to rave together.",
+  "hometown": "Burr Ridge, Illinois",
+  "teamRoles": [
+    {
+      "team": "Penn Courses",
+      "roles": ["Backend Engineer", "Team Lead"]
+    }
+  ],
+  "photo": "https://i.imgur.com/Cbh9UsT.jpeg",
+  "linkedin": "https://www.linkedin.com/in/shiva-menta-472750147/",
+  "website": "https://shivamenta.me/",
+  "github": "https://github.com/shiva-menta",
+  "semester_joined": "2023A",
+  "alumnus": false,
+  "graduation_year": 2024,
+  "job": null
+}

--- a/src/json/members/sxd4383.json
+++ b/src/json/members/sxd4383.json
@@ -5,9 +5,13 @@
     "school": "Engineering, Wharton, and Design",
     "bio": "A story-driven designer who leads with empathy & a passion for global development",
     "hometown": "Qingdao, China",
-    "team": "Penn Mobile",
-    "roles": ["Designer"],
-    "photo":"https://i.imgur.com/etk3YqO.jpg",
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Designer"]
+      }
+    ],
+    "photo": "https://i.imgur.com/etk3YqO.jpg",
     "linkedin": "https://www.linkedin.com/in/sherry-xue/",
     "website": "https://sherryx.webflow.io/",
     "github": "",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2025,
     "job": null
-}
+  }
+  

--- a/src/json/members/tngulube.json
+++ b/src/json/members/tngulube.json
@@ -5,8 +5,12 @@
   "school": "SEAS",
   "bio": "Hi. I'm Thomas, a student in The School of Engineering studying Computer Science.  lorem ipsum dolor sit amet, consectetur adipiscing elit.",
   "hometown": "Kitwe, Zambia",
-  "team": "Penn Clubs",
-  "roles": ["Backend Developer"],
+  "teamRoles": [
+    {
+      "team": "Penn Clubs",
+      "roles": ["Backend Developer"]
+    }
+  ],
   "photo": "https://i.imgur.com/P7jUtb2.jpg",
   "linkedin": "https://www.linkedin.com/in/thomasngulube/",
   "website": "",

--- a/src/json/members/trini.json
+++ b/src/json/members/trini.json
@@ -5,8 +5,12 @@
     "school": "Engineering",
     "bio": "Hi! I'm a freshman from Illinois, and I'm majoring in CIS. In my free time, I like writing poetry, playing music, and half-finishing crosswords.",
     "hometown": "Crystal Lake, IL",
-    "team": "Penn Mobile",
-    "roles": ["Android Mobile Engineer"],
+    "teamRoles": [
+      {
+        "team": "Penn Mobile",
+        "roles": ["Android Mobile Engineer"]
+      }
+    ],
     "photo": "https://i.imgur.com/LyTB20B.jpg",
     "linkedin": "https://www.linkedin.com/in/trini-feng-2b8836233/",
     "website": "",
@@ -15,4 +19,5 @@
     "alumnus": false,
     "graduation_year": 2027,
     "job": null
-}
+  }
+  

--- a/src/json/members/tuneer.json
+++ b/src/json/members/tuneer.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Food tries to kill me a lot, but I'm still here! I like biking and playing guitar although I can't do either particularly well.",
   "hometown": "Nashville, TN",
-  "team": "Penn Mobile",
-  "roles": ["Backend Engineer", "Team Lead"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Backend Engineer", "Team Lead"]
+    }
+  ],
   "photo": "https://i.imgur.com/1zDQ0UG.png",
   "linkedin": "https://www.linkedin.com/in/tuneer-roy-a792a11a4",
   "website": "https://tuneer-roy.com/",

--- a/src/json/members/tyding.json
+++ b/src/json/members/tyding.json
@@ -5,8 +5,12 @@
   "school": "SEAS & Wharton",
   "bio": "Hi, I use VIM.",
   "hometown": "Toronto, ON",
-  "team": "Penn Mobile",
-  "roles": ["Backend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Backend Engineer"]
+    }
+  ],
   "photo": "https://jeffersonding.com/headshot.png",
   "linkedin": "https://www.linkedin.com/in/dingjefferson",
   "website": "https://jeffersonding.com",

--- a/src/json/members/vavali.json
+++ b/src/json/members/vavali.json
@@ -5,8 +5,12 @@
   "school": "Engineering",
   "bio": "Hi, I'm Vedha and my favorite things are food and my golden retriever.",
   "hometown": "Pittsburgh, PA",
-  "team": "Penn Mobile",
-  "roles": ["Android Mobile Engineer"],
+  "teamRoles": [
+    {
+      "team": "Penn Mobile",
+      "roles": ["Android Mobile Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/bVCbRVf.jpg",
   "linkedin": "https://www.linkedin.com/in/vedha-avali/",
   "website": "",

--- a/src/json/members/willguo6.json
+++ b/src/json/members/willguo6.json
@@ -5,8 +5,12 @@
   "school": "Wharton",
   "bio": "Hi! I'm William, sophomore studying Statistics. Find me in a Huntsman GSR eating Chipotle or playing pickup soccer at Penn Park.",
   "hometown": "Portland, OR",
-  "team": "Office Hours Queue",
-  "roles": ["Frontend Engineer"],
+  "teamRoles": [
+    {
+      "team": "Office Hours Queue",
+      "roles": ["Frontend Engineer"]
+    }
+  ],
   "photo": "https://i.imgur.com/RvGNbJY.jpg",
   "linkedin": "https://www.linkedin.com/in/william-guo-0b458118a/",
   "website": "",

--- a/src/json/teams.json
+++ b/src/json/teams.json
@@ -9,7 +9,7 @@
   },
   {
     "name": "Penn Clubs",
-    "description": "Penn Clubs team is responsible for building and maintaining Penn Clubs, the central source of information about student organizations on campus. Penn Clubs is our newest product and we can't wait to watch it grow!"
+    "description": "We build and maintain Penn Clubs: the central hub for student organizations on campus, from recruiting to event tickets and more!"
   },
   {
     "name": "Penn Courses",

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -69,9 +69,6 @@ export const pageQuery = graphql`
         description
         members {
           name
-          team {
-            name
-          }
           pennkey
           photo
           semester_joined
@@ -90,12 +87,16 @@ export const pageQuery = graphql`
     allAlumniJson {
       nodes {
         name
-        team
         pennkey
         photo
         semester_joined
         alumnus
-        roles
+        teamRoles {
+          team {
+            name
+          }
+          roles
+        }
       }
     }
   }

--- a/src/templates/members/Alumnus.tsx
+++ b/src/templates/members/Alumnus.tsx
@@ -21,11 +21,15 @@ export const pageQuery = graphql`
           }
         }
       }
-      roles
+      teamRoles {
+        team {
+          name
+        }
+        roles
+      }
       name
       major
       school
-      team
       website
       semester_joined
       alumnus

--- a/src/templates/members/Member.tsx
+++ b/src/templates/members/Member.tsx
@@ -21,12 +21,14 @@ export const pageQuery = graphql`
           }
         }
       }
-      roles
       name
       major
       school
-      team {
-        name
+      teamRoles {
+        team {
+          name
+        }
+        roles
       }
       website
       semester_joined

--- a/src/templates/members/utils.tsx
+++ b/src/templates/members/utils.tsx
@@ -212,11 +212,10 @@ export const GenericMemberTemplate = ({
     hometown: location,
     photo,
     localImage,
-    roles,
     name,
     major,
     school,
-    team,
+    teamRoles,
     website,
     semester_joined: semesterJoined,
     posts,
@@ -227,6 +226,9 @@ export const GenericMemberTemplate = ({
   markdownProcessor
     .process(bio || '')
     .then(({ contents: b }) => updateBioAsHtml(b as any))
+
+  const roles = [...new Set(teamRoles?.map(t => t.roles).flat())] ?? []
+  const team = teamRoles?.map(t => t.team).flat() ?? ['Penn Labs']
 
   return (
     <Layout>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,12 +30,16 @@ export interface IPost {
   timeToRead?: number
 }
 
+export interface ITeamRole {
+  team: ITeam
+  roles: IRole[]
+}
+
 export interface IMember {
   name: string
   major?: string
   school?: string
   photo?: string
-  roles: string[]
   pennkey: string
   semester_joined?: string
   alumnus: boolean
@@ -44,10 +48,14 @@ export interface IMember {
   graduation_year?: string
   linkedin?: string
   hometown?: string
-  team?: ITeam[] | ITeam
+  teamRoles: ITeamRole[]
   website?: string
   localImage?: { childImageSharp: GatsbyImageFluidProps }
   posts?: IPost[]
+}
+
+export interface ITeamMember extends IMember {
+  roles: string[]
 }
 
 export interface ITeam {


### PR DESCRIPTION
* Building off #250, allows users to define their roles on a team-by-team basis (e.g. a team lead on one team can contribute to other teams without showing up as team lead on all teams, retired platform member can join iOS without doing "devops" for iOS)

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/pennlabs/website/assets/10285518/4054a8ef-f44a-4f75-9f56-180d192cc1f4)  | ![image](https://github.com/pennlabs/website/assets/10285518/eec49a62-1972-4a2e-bd88-725cd128d660) |
| ![image](https://github.com/pennlabs/website/assets/10285518/d8c45847-2371-4cf1-b91e-94aa5f7ff2ce) | ![image](https://github.com/pennlabs/website/assets/10285518/ff1844c3-4c7a-4b15-bb08-d61d3862efa5) |

To my understanding, @joyliu-q , @esinx , @Clue88 , and @anli5005 are the only people who would fall under multiple teams currently, I separated some roles for demo purposes but feel free to self-define roles etc.

* Fix ezwang page 404ing

* Fix alumni not having their specific teams on their individual bio pages

* Fix description of Penn Clubs to not say we're the newest product 