### PR TITLE
Added banner for incident status

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,4 +4,14 @@
  * See: https://www.gatsbyjs.org/docs/ssr-apis/
  */
 
-// You can delete this file if you're not using it
+const React = require('react')
+
+exports.onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <script
+      key="pennlabs-status-banner"
+      src="https://status.pennlabs.org/banner.js"
+      defer
+    />,
+  ])
+}


### PR DESCRIPTION
Reference for more information:
https://github.com/pennlabs/status/pull/4
https://github.com/pennlabs/office-hours-queue/pull/339

This is part of an ongoing effort to add status banners during incidents to every labs page when we're experiencing an outage.